### PR TITLE
Add ticker optimisation for Buy and Hold strategy

### DIFF
--- a/src/quant_trading_strategy_backtester/streamlit_ui.py
+++ b/src/quant_trading_strategy_backtester/streamlit_ui.py
@@ -20,7 +20,7 @@ def get_user_inputs_except_strategy_params() -> (
     Returns:
         A tuple containing the ticker symbol(s), start date, end date, strategy
         type, and a boolean indicating whether to use automatic ticker
-        selection for pairs trading.
+        selection for pairs trading or buy and hold.
     """
     strategy_type = cast(
         str, st.sidebar.selectbox("Strategy Type", TRADING_STRATEGIES, index=0)
@@ -41,6 +41,14 @@ def get_user_inputs_except_strategy_params() -> (
                 "Ticker Symbol 2", value="GOOGL"
             ).upper()
             ticker = (ticker1, ticker2)
+    elif strategy_type == "Buy and Hold":
+        auto_select_tickers = st.sidebar.checkbox(
+            f"Optimise Ticker From Top {NUM_TOP_COMPANIES} S&P 500 Companies"
+        )
+        if auto_select_tickers:
+            ticker = None  # We'll select the ticker later
+        else:
+            ticker = st.sidebar.text_input("Ticker Symbol", value="AAPL").upper()
     else:
         ticker = st.sidebar.text_input("Ticker Symbol", value="AAPL").upper()
 

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -144,9 +144,11 @@ def test_run_optimisation(monkeypatch):
 
     strategy_type = "Mean Reversion"
     initial_params = {"window": 20, "std_dev": 2.0}
+    start_date = datetime.date(2020, 1, 1)
+    end_date = datetime.date(2020, 12, 31)
 
     optimised_params, metrics = run_optimisation(
-        mock_polars_data, strategy_type, initial_params
+        mock_polars_data, strategy_type, initial_params, start_date, end_date
     )
 
     assert isinstance(optimised_params, dict)


### PR DESCRIPTION
# Summary

- Added ticker optimisation for the Buy and Hold strategy
  - Similarly to the Pairs Trading optimiser, it looks at the top `x` S&P 500 companies (currently 20) and runs backtests on all of them for the date range
  - Out of those companies, it selects the best performing ticker by Sharpe ratio

## Related Issues

Fixes [#28](https://github.com/IsaacCheng9/quant-trading-strategy-backtester/issues/28)

## Screenshots

<img width="1017" alt="image" src="https://github.com/user-attachments/assets/f55e6dfa-c041-43c8-8e6b-cad1e26e0d60">

<img width="1018" alt="image" src="https://github.com/user-attachments/assets/16b13f32-218f-45a2-9abb-3a101625976e">
