### PR TITLE
Add ticker optimisation for mean reversion and moving average crossover strategies

### DIFF
--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -160,12 +160,17 @@ def prepare_single_ticker_strategy_with_optimisation(
     duration = end_time - start_time
     st.success(f"Optimisation complete! Time taken: {duration:.4f} seconds")
 
-    # Display the optimal ticker and parameters
+    # Display the optimal ticker and parameters (if optimised)
     st.header("Optimal Ticker and Parameters")
-    result = {
-        "ticker": best_ticker,
-        **best_params,
-    }
+    if optimise:
+        result = {
+            "ticker": best_ticker,
+            **best_params,
+        }
+    else:
+        result = {
+            "ticker": best_ticker,
+        }
     st.write(result)
 
     return data, best_ticker, best_params

--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -24,6 +24,8 @@ from quant_trading_strategy_backtester.data import (
 from quant_trading_strategy_backtester.optimiser import (
     optimise_buy_and_hold_ticker,
     optimise_pairs_trading_tickers,
+    optimise_single_ticker_strategy_ticker,
+    optimise_strategy_params,
     run_backtest,
     run_optimisation,
 )
@@ -36,8 +38,8 @@ from quant_trading_strategy_backtester.utils import (
     NUM_TOP_COMPANIES_TWO_TICKERS,
 )
 from quant_trading_strategy_backtester.visualisation import (
-    display_returns_by_month,
     display_performance_metrics,
+    display_returns_by_month,
     plot_equity_curve,
     plot_strategy_returns,
 )
@@ -93,6 +95,80 @@ def prepare_buy_and_hold_strategy_with_optimisation(
     data = load_yfinance_data_one_ticker(best_ticker, start_date, end_date)
 
     return data, best_ticker, {}
+
+
+def prepare_single_ticker_strategy_with_optimisation(
+    start_date: datetime.date,
+    end_date: datetime.date,
+    strategy_type: str,
+    strategy_params: dict[str, Any],
+    optimise: bool,
+) -> tuple[pl.DataFrame, str, dict[str, Any]]:
+    """
+    Handles the optimisation process for single ticker strategies.
+
+    Selects the best ticker from the top S&P 500 companies and optimises
+    strategy parameters if requested.
+
+    Args:
+        start_date: The start date for historical data.
+        end_date: The end date for historical data.
+        strategy_type: The type of strategy being used.
+        strategy_params: Initial strategy parameters.
+        optimise: Whether to optimise strategy parameters.
+
+    Returns:
+        A tuple containing:
+            - Historical data for the selected ticker.
+            - The selected ticker symbol.
+            - Optimised strategy parameters.
+    """
+    st.info(
+        f"Selecting the best ticker from the top {NUM_TOP_COMPANIES_ONE_TICKER} S&P 500 "
+        "companies. This may take a while..."
+    )
+
+    start_time = time.time()
+
+    # Fetch the top S&P 500 companies
+    with st.spinner("Fetching top S&P 500 companies..."):
+        top_companies = get_top_sp500_companies(NUM_TOP_COMPANIES_ONE_TICKER)
+
+    # Optimise ticker selection
+    best_ticker = optimise_single_ticker_strategy_ticker(
+        top_companies, start_date, end_date, strategy_type, strategy_params
+    )
+
+    # Load historical data for the selected ticker
+    data = load_yfinance_data_one_ticker(best_ticker, start_date, end_date)
+
+    # Optimise strategy parameters if requested
+    if optimise:
+        best_params, _ = optimise_strategy_params(
+            data,
+            strategy_type,
+            cast(dict[str, range] | dict[str, list[float]], strategy_params),
+        )
+    else:
+        best_params = {
+            k: v[0] if isinstance(v, (list, range)) else v
+            for k, v in strategy_params.items()
+        }
+
+    # Calculate and display the time taken for optimisation
+    end_time = time.time()
+    duration = end_time - start_time
+    st.success(f"Optimisation complete! Time taken: {duration:.4f} seconds")
+
+    # Display the optimal ticker and parameters
+    st.header("Optimal Ticker and Parameters")
+    result = {
+        "ticker": best_ticker,
+        **best_params,
+    }
+    st.write(result)
+
+    return data, best_ticker, best_params
 
 
 def prepare_pairs_trading_strategy_with_optimisation(
@@ -287,9 +363,15 @@ def main():
         ticker1, ticker2 = cast(tuple[str, str], ticker)
         company_name1 = get_full_company_name(ticker1)
         company_name2 = get_full_company_name(ticker2)
-    elif strategy_type == "Buy and Hold" and auto_select_tickers:
+    # Optimise the ticker for single ticker strategies if option is selected
+    elif (
+        strategy_type in ["Buy and Hold", "Mean Reversion", "Moving Average Crossover"]
+        and auto_select_tickers
+    ):
         data, ticker_display, strategy_params = (
-            prepare_buy_and_hold_strategy_with_optimisation(start_date, end_date)
+            prepare_single_ticker_strategy_with_optimisation(
+                start_date, end_date, strategy_type, strategy_params, optimise
+            )
         )
         company_name1 = get_full_company_name(ticker_display)
     else:

--- a/src/quant_trading_strategy_backtester/data.py
+++ b/src/quant_trading_strategy_backtester/data.py
@@ -114,9 +114,10 @@ def get_top_sp500_companies(num_companies: int) -> list[tuple[str, float]]:
                 sp500_companies.append((ticker, market_cap))
 
     # Sort companies by market cap (descending) and take the top X companies.
-    top_companies = sorted(sp500_companies, key=lambda x: x[1], reverse=True)[
-        :num_companies
-    ]
+    sorted_companies = sorted(sp500_companies, key=lambda x: x[1], reverse=True)
+    top_companies = (
+        sorted_companies[:num_companies] if num_companies > 0 else sorted_companies
+    )
 
     return top_companies
 

--- a/src/quant_trading_strategy_backtester/streamlit_ui.py
+++ b/src/quant_trading_strategy_backtester/streamlit_ui.py
@@ -8,7 +8,10 @@ from typing import Any, cast
 
 import streamlit as st
 from quant_trading_strategy_backtester.strategy_templates import TRADING_STRATEGIES
-from quant_trading_strategy_backtester.utils import NUM_TOP_COMPANIES_ONE_TICKER, NUM_TOP_COMPANIES_TWO_TICKERS
+from quant_trading_strategy_backtester.utils import (
+    NUM_TOP_COMPANIES_ONE_TICKER,
+    NUM_TOP_COMPANIES_TWO_TICKERS,
+)
 
 
 def get_user_inputs_except_strategy_params() -> (
@@ -27,9 +30,11 @@ def get_user_inputs_except_strategy_params() -> (
     )
 
     auto_select_tickers = False
+    # Two ticker strategies
     if strategy_type == "Pairs Trading":
         auto_select_tickers = st.sidebar.checkbox(
-            f"Optimise Ticker Pair From Top {NUM_TOP_COMPANIES_TWO_TICKERS} S&P 500 Companies"
+            f"Optimise Ticker Pair From Top {NUM_TOP_COMPANIES_TWO_TICKERS} S&P 500 "
+            "Companies"
         )
         if auto_select_tickers:
             ticker = None  # We'll select tickers later
@@ -41,7 +46,12 @@ def get_user_inputs_except_strategy_params() -> (
                 "Ticker Symbol 2", value="GOOGL"
             ).upper()
             ticker = (ticker1, ticker2)
-    elif strategy_type == "Buy and Hold":
+    # One ticker strategies
+    elif strategy_type in [
+        "Buy and Hold",
+        "Mean Reversion",
+        "Moving Average Crossover",
+    ]:
         auto_select_tickers = st.sidebar.checkbox(
             f"Optimise Ticker From Top {NUM_TOP_COMPANIES_ONE_TICKER} S&P 500 Companies"
         )

--- a/src/quant_trading_strategy_backtester/utils.py
+++ b/src/quant_trading_strategy_backtester/utils.py
@@ -5,5 +5,5 @@ Contains utility code and constants used throughout the project.f
 import logging
 
 logger = logging.getLogger(__name__)
-NUM_TOP_COMPANIES_ONE_TICKER = 50
+NUM_TOP_COMPANIES_ONE_TICKER = 100
 NUM_TOP_COMPANIES_TWO_TICKERS = 20

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -10,10 +10,12 @@ import pytest
 from quant_trading_strategy_backtester.app import (
     prepare_buy_and_hold_strategy_with_optimisation,
     prepare_pairs_trading_strategy_with_optimisation,
+    prepare_single_ticker_strategy_with_optimisation,
 )
 from quant_trading_strategy_backtester.optimiser import (
     optimise_buy_and_hold_ticker,
     optimise_pairs_trading_tickers,
+    optimise_single_ticker_strategy_ticker,
     run_backtest,
     run_optimisation,
 )
@@ -337,3 +339,166 @@ def test_run_backtest(
 def test_run_backtest_invalid_strategy() -> None:
     with pytest.raises(ValueError, match="Invalid strategy type"):
         run_backtest(pl.DataFrame(), "Invalid Strategy", {})
+
+
+def test_optimise_single_ticker_strategy_ticker(monkeypatch):
+    # Mock data and functions
+    mock_top_companies = [("AAPL", 1000000.0), ("GOOGL", 900000.0), ("MSFT", 800000.0)]
+    mock_polars_data = pl.DataFrame(
+        {
+            "Date": [datetime.date(2020, 1, i) for i in range(1, 32)],
+            "Close": [100 + i for i in range(31)],
+        }
+    )
+
+    def mock_load_data(*args, **kwargs):
+        return mock_polars_data
+
+    def mock_run_backtest(*args, **kwargs):
+        strategy_type = args[1]
+        if strategy_type == "Moving Average Crossover":
+            return None, {"Sharpe Ratio": 1.5}
+        elif strategy_type == "Mean Reversion":
+            return None, {"Sharpe Ratio": 1.2}
+        else:
+            return None, {"Sharpe Ratio": 1.0}
+
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.load_yfinance_data_one_ticker",
+        mock_load_data,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.run_backtest",
+        mock_run_backtest,
+    )
+
+    start_date = datetime.date(2020, 1, 1)
+    end_date = datetime.date(2020, 12, 31)
+    strategy_type = "Moving Average Crossover"
+    strategy_params = {"short_window": 10, "long_window": 50}
+
+    best_ticker = optimise_single_ticker_strategy_ticker(
+        mock_top_companies, start_date, end_date, strategy_type, strategy_params
+    )
+
+    assert isinstance(best_ticker, str)
+    assert best_ticker in [company[0] for company in mock_top_companies]
+
+
+def test_prepare_single_ticker_strategy_with_optimisation(monkeypatch):
+    # Mock data and functions
+    mock_polars_data = pl.DataFrame(
+        {
+            "Date": [datetime.date(2020, 1, i) for i in range(1, 32)],
+            "Close": [100 + i for i in range(31)],
+        }
+    )
+    mock_top_companies = [("AAPL", 1000000.0), ("GOOGL", 900000.0), ("MSFT", 800000.0)]
+
+    def mock_get_top_companies(*args, **kwargs):
+        return mock_top_companies
+
+    def mock_optimise_single_ticker(*args, **kwargs):
+        return "AAPL"
+
+    def mock_load_data(*args, **kwargs):
+        return mock_polars_data
+
+    def mock_optimise_strategy_params(*args, **kwargs):
+        return {"short_window": 15, "long_window": 60}, {"Sharpe Ratio": 1.8}
+
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.app.get_top_sp500_companies",
+        mock_get_top_companies,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.app.optimise_single_ticker_strategy_ticker",
+        mock_optimise_single_ticker,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.app.load_yfinance_data_one_ticker",
+        mock_load_data,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.app.optimise_strategy_params",
+        mock_optimise_strategy_params,
+    )
+
+    start_date = datetime.date(2020, 1, 1)
+    end_date = datetime.date(2020, 12, 31)
+    strategy_type = "Moving Average Crossover"
+    strategy_params = {
+        "short_window": range(5, 30, 5),
+        "long_window": range(20, 100, 10),
+    }
+    optimise = True
+
+    data, ticker_display, optimised_params = (
+        prepare_single_ticker_strategy_with_optimisation(
+            start_date, end_date, strategy_type, strategy_params, optimise
+        )
+    )
+
+    assert isinstance(data, pl.DataFrame)
+    assert isinstance(ticker_display, str)
+    assert ticker_display == "AAPL"
+    assert isinstance(optimised_params, dict)
+    assert set(optimised_params.keys()) == {"short_window", "long_window"}
+    assert optimised_params["short_window"] == 15
+    assert optimised_params["long_window"] == 60
+
+
+def test_prepare_single_ticker_strategy_with_optimisation_no_param_optimisation(
+    monkeypatch,
+):
+    # Mock data and functions
+    mock_polars_data = pl.DataFrame(
+        {
+            "Date": [datetime.date(2020, 1, i) for i in range(1, 32)],
+            "Close": [100 + i for i in range(31)],
+        }
+    )
+    mock_top_companies = [("AAPL", 1000000.0), ("GOOGL", 900000.0), ("MSFT", 800000.0)]
+
+    def mock_get_top_companies(*args, **kwargs):
+        return mock_top_companies
+
+    def mock_optimise_single_ticker(*args, **kwargs):
+        return "AAPL"
+
+    def mock_load_data(*args, **kwargs):
+        return mock_polars_data
+
+    def mock_optimise_strategy_params(*args, **kwargs):
+        return {"short_window": 15, "long_window": 60}, {"Sharpe Ratio": 1.8}
+
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.app.get_top_sp500_companies",
+        mock_get_top_companies,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.app.optimise_single_ticker_strategy_ticker",
+        mock_optimise_single_ticker,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.app.load_yfinance_data_one_ticker",
+        mock_load_data,
+    )
+
+    start_date = datetime.date(2020, 1, 1)
+    end_date = datetime.date(2020, 12, 31)
+    strategy_type = "Moving Average Crossover"
+    strategy_params = {"short_window": 10, "long_window": 50}
+    optimise = False
+
+    data, ticker_display, final_params = (
+        prepare_single_ticker_strategy_with_optimisation(
+            start_date, end_date, strategy_type, strategy_params, optimise
+        )
+    )
+
+    assert isinstance(data, pl.DataFrame)
+    assert isinstance(ticker_display, str)
+    assert ticker_display == "AAPL"
+    assert isinstance(final_params, dict)
+    assert final_params == strategy_params  # Parameters should remain unchanged


### PR DESCRIPTION
# Summary

- Added ticker optimisation for mean reversion and moving average crossover strategies
  - Selects the ticker out of the top 100 S&P 500 companies for the strategy

## Related Issues

Fixes [#35](https://github.com/IsaacCheng9/quant-trading-strategy-backtester/issues/35)

## Screenshots

<img width="1264" alt="image" src="https://github.com/user-attachments/assets/bdbda38d-e522-44d5-a464-0e335babbc20">

<img width="1265" alt="image" src="https://github.com/user-attachments/assets/b10be12e-6f47-4d95-986b-423aabe4325e">
