### PR TITLE
Use Streamlit session state to persist historical strategy strategy in deployed instances

### DIFF
--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -17,6 +17,7 @@ from typing import Any, cast
 import polars as pl
 import streamlit as st
 
+from quant_trading_strategy_backtester.backtester import is_running_locally
 from quant_trading_strategy_backtester.data import (
     get_full_company_name,
     get_top_sp500_companies,
@@ -346,45 +347,77 @@ def prepare_single_ticker_strategy(
 
 def display_historical_results():
     """
-    Displays historical strategy results from the database in an organised
-    format, showing only the most recent entry for each unique strategy.
+    Displays historical strategy results from either the database or session state,
+    depending on the environment.
     """
-    session = Session()
-    strategies = (
-        session.query(StrategyModel).order_by(StrategyModel.date_created.desc()).all()
-    )
-    session.close()
+    if is_running_locally():
+        # Use SQLite (existing code)
+        session = Session()
+        strategies = (
+            session.query(StrategyModel)
+            .order_by(StrategyModel.date_created.desc())
+            .all()
+        )
+        session.close()
+    else:
+        # Use Streamlit session state
+        if "strategy_results" not in st.session_state:
+            strategies = []
+        else:
+            strategies = sorted(
+                st.session_state.strategy_results,
+                key=lambda x: x["date_created"],
+                reverse=True,
+            )
 
     if not strategies:
         st.info("No historical strategy results available.")
         return
 
+    if not is_running_locally():
+        st.info("""
+            📝 **Note about Results History:**
+            - Strategy results are saved within your current session
+            - Results will be available as long as you keep this tab open
+            - Results are reset when you refresh the page or start a new session
+            """)
+
     st.header("Historical Strategy Results")
 
-    # Group strategies by name and parameters
-    unique_strategies = {}
+    # Display strategies
     for strategy in strategies:
-        # Handle cases where parameters might be a string or a dict
-        if isinstance(strategy.parameters, str):
-            params = json.loads(strategy.parameters)
+        # Handle either SQLite model or session state dict
+        if is_running_locally():
+            strategy_name = strategy.name
+            date_created = strategy.date_created
+            try:
+                tickers = json.loads(str(strategy.tickers))
+            except (json.JSONDecodeError, TypeError):
+                tickers = strategy.tickers
+            try:
+                params = json.loads(str(strategy.parameters))
+            except (json.JSONDecodeError, TypeError):
+                params = strategy.parameters  # type: ignore
+            total_return = strategy.total_return
+            sharpe_ratio: float = strategy.sharpe_ratio  # type: ignore
+            max_drawdown = strategy.max_drawdown
+            start_date = strategy.start_date
+            end_date = strategy.end_date
         else:
-            params = strategy.parameters
+            strategy_name = strategy["name"]
+            date_created = strategy["date_created"]
+            tickers = strategy["tickers"]
+            params: dict = strategy["parameters"]
+            total_return = strategy["total_return"]
+            sharpe_ratio: float = strategy["sharpe_ratio"]
+            max_drawdown = strategy["max_drawdown"]
+            start_date = strategy["start_date"]
+            end_date = strategy["end_date"]
 
-        # Handle cases where tickers might be a string or a list
-        if isinstance(strategy.tickers, str):
-            tickers = json.loads(strategy.tickers)
-        else:
-            tickers = strategy.tickers
-
-        key = (strategy.name, frozenset(params.items()))
-        if key not in unique_strategies:
-            unique_strategies[key] = (strategy, tickers)
-
-    # Display only the most recent entry for each unique strategy
-    for (strategy_name, params), (strategy, tickers) in unique_strategies.items():
         ticker_display = " vs. ".join(tickers) if isinstance(tickers, list) else tickers
+
         with st.expander(
-            f"{strategy_name} - {ticker_display} - {strategy.date_created.strftime('%Y-%m-%d %H:%M:%S')}"
+            f"{strategy_name} - {ticker_display} - {date_created.strftime('%Y-%m-%d %H:%M:%S')}"
         ):
             col1, col2 = st.columns(2)
 
@@ -393,23 +426,23 @@ def display_historical_results():
                 st.write(f"**Strategy Type:** {strategy_name}")
                 st.write(f"**Ticker(s):** {ticker_display}")
                 st.write(
-                    f"**Date Created:** {strategy.date_created.strftime('%Y-%m-%d %H:%M:%S')}"
+                    f"**Date Created:** {date_created.strftime('%Y-%m-%d %H:%M:%S')}"
                 )
-                st.write(f"**Start Date:** {strategy.start_date}")
-                st.write(f"**End Date:** {strategy.end_date}")
+                st.write(f"**Start Date:** {start_date}")
+                st.write(f"**End Date:** {end_date}")
 
                 st.subheader("Parameters")
-                for key, value in dict(params).items():
+                for key, value in (params or {}).items():
                     st.write(f"**{key}:** {value}")
 
             with col2:
                 st.subheader("Performance Metrics")
-                st.write(f"**Total Return:** {strategy.total_return:.2%}")
-                if strategy.sharpe_ratio:
-                    st.write(f"**Sharpe Ratio:** {strategy.sharpe_ratio:.2f}")
+                st.write(f"**Total Return:** {total_return:.2%}")
+                if sharpe_ratio:
+                    st.write(f"**Sharpe Ratio:** {sharpe_ratio:.2f}")
                 else:
                     st.write("**Sharpe Ratio:** N/A")
-                st.write(f"**Max Drawdown:** {strategy.max_drawdown:.2%}")
+                st.write(f"**Max Drawdown:** {max_drawdown:.2%}")
 
             st.write("---")
 

--- a/src/quant_trading_strategy_backtester/models.py
+++ b/src/quant_trading_strategy_backtester/models.py
@@ -36,7 +36,7 @@ class StrategyModel(Base):
     __tablename__ = "strategies"
 
     id = Column(Integer, primary_key=True)
-    date_created = Column(DateTime, default=datetime.datetime.now())
+    date_created = Column(DateTime, default=datetime.datetime.now)
     name = Column(String, nullable=False)
     parameters = Column(JSON, nullable=False)
     total_return = Column(Float, nullable=False)


### PR DESCRIPTION
# Summary

- Streamlit's hosted environment doesn't support file write operations for security reasons, so the current SQLite persistence doesn't work and it breaks the deployed app
- We'll use the Streamlit session state to persist it instead
- Downsides are that data is lost whenever:
  - The user refreshes the page
  - The Streamlit app restarts
  - The user opens the app in a new tab
  - The session expires

## Related Issues
Fixes [#41](https://github.com/IsaacCheng9/quant-trading-strategy-backtester/issues/41)