### PR TITLE
fix: Use Polars' lazy evaluation instead of eager execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dev-dependencies = [
     "coverage<8.0.0,>=7.6.0",
     "pandas-stubs<3.0.0.0,>=2.2.2.240603",
     "pytest-cov<6.0.0,>=5.0.0",
-    "ty>=0.0.12",
+    "ty>=0.0.21",
 ]
 
 [tool.poe.tasks]

--- a/src/quant_trading_strategy_backtester/backtester.py
+++ b/src/quant_trading_strategy_backtester/backtester.py
@@ -108,30 +108,37 @@ class Backtester:
         else:
             raise ValueError("Data does not contain required 'Close' columns")
 
-        portfolio = signals.with_columns(
-            [
-                pl.col("position_change"),
-                asset_returns.alias("asset_returns"),
-                (pl.col("signal").shift(1) * asset_returns).alias("strategy_returns"),
-            ]
-        )
-
-        # Handle potential NaN or inf values
-        portfolio = portfolio.with_columns(
-            [
-                pl.col("strategy_returns")
-                .replace({float("inf"): None, float("-inf"): None})
-                .fill_null(0)
-            ]
-        )
-
-        portfolio = portfolio.with_columns(
-            [
-                (1 + pl.col("strategy_returns")).cum_prod().alias("cumulative_returns"),
-                (
-                    self.initial_capital * (1 + pl.col("strategy_returns")).cum_prod()
-                ).alias("equity_curve"),
-            ]
+        portfolio = (
+            signals.lazy()
+            .with_columns(
+                [
+                    pl.col("position_change"),
+                    asset_returns.alias("asset_returns"),
+                    (pl.col("signal").shift(1) * asset_returns).alias(
+                        "strategy_returns"
+                    ),
+                ]
+            )
+            # Handle potential NaN or inf values.
+            .with_columns(
+                [
+                    pl.col("strategy_returns")
+                    .replace({float("inf"): None, float("-inf"): None})
+                    .fill_null(0)
+                ]
+            )
+            .with_columns(
+                [
+                    (1 + pl.col("strategy_returns"))
+                    .cum_prod()
+                    .alias("cumulative_returns"),
+                    (
+                        self.initial_capital
+                        * (1 + pl.col("strategy_returns")).cum_prod()
+                    ).alias("equity_curve"),
+                ]
+            )
+            .collect()
         )
 
         return portfolio

--- a/src/quant_trading_strategy_backtester/backtester.py
+++ b/src/quant_trading_strategy_backtester/backtester.py
@@ -108,7 +108,7 @@ class Backtester:
         else:
             raise ValueError("Data does not contain required 'Close' columns")
 
-        portfolio = (
+        portfolio: pl.DataFrame = (  # type: ignore[invalid-assignment]
             signals.lazy()
             .with_columns(
                 [

--- a/src/quant_trading_strategy_backtester/strategies/buy_and_hold.py
+++ b/src/quant_trading_strategy_backtester/strategies/buy_and_hold.py
@@ -41,7 +41,7 @@ class BuyAndHoldStrategy(BaseStrategy):
                 ]
             )
 
-        signals = (
+        signals: pl.DataFrame = (  # type: ignore[invalid-assignment]
             data.select([pl.col("Date"), pl.col("Close")])
             .lazy()
             .with_columns(

--- a/src/quant_trading_strategy_backtester/strategies/buy_and_hold.py
+++ b/src/quant_trading_strategy_backtester/strategies/buy_and_hold.py
@@ -41,13 +41,16 @@ class BuyAndHoldStrategy(BaseStrategy):
                 ]
             )
 
-        signals = data.select([pl.col("Date"), pl.col("Close")])
-        # Add the 'signal' and 'position_change' columns.
-        signals = signals.with_columns(
-            [
-                pl.lit(1.0).alias("signal"),
-                pl.lit(1.0).alias("position_change"),
-            ]
+        signals = (
+            data.select([pl.col("Date"), pl.col("Close")])
+            .lazy()
+            .with_columns(
+                [
+                    pl.lit(1.0).alias("signal"),
+                    pl.lit(1.0).alias("position_change"),
+                ]
+            )
+            .collect()
         )
 
         return signals

--- a/src/quant_trading_strategy_backtester/strategies/mean_reversion.py
+++ b/src/quant_trading_strategy_backtester/strategies/mean_reversion.py
@@ -61,49 +61,60 @@ class MeanReversionStrategy(BaseStrategy):
                 ]
             )
 
-        signals = data.select([pl.col("Date"), pl.col("Close")])
-        signals = signals.with_columns(
-            [
-                pl.col("Close")
-                .rolling_mean(window_size=self.window, min_samples=self.window)
-                .alias("mean"),
-                pl.col("Close")
-                .rolling_std(window_size=self.window, min_samples=self.window)
-                .alias("std"),
-            ]
-        )
-        # Avoid division by zero by replacing 0s with NaN.
-        signals = signals.with_columns(
-            [
-                pl.when(pl.col("std") == 0)
-                .then(pl.lit(float("nan")))
-                .otherwise(pl.col("std"))
-                .alias("std")
-            ]
-        )
-
-        signals = signals.with_columns(
-            [
-                (pl.col("mean") + (self.std_dev * pl.col("std"))).alias("upper_band"),
-                (pl.col("mean") - (self.std_dev * pl.col("std"))).alias("lower_band"),
-            ]
-        )
-
-        signals = signals.with_columns(
-            [
-                # Buy signal
-                pl.when(pl.col("Close") < pl.col("lower_band"))
-                .then(1.0)
-                # Sell signal
-                .when(pl.col("Close") > pl.col("upper_band"))
-                .then(-1.0)
-                .otherwise(0.0)
-                .alias("signal")
-            ]
-        )
-
-        signals = signals.with_columns(
-            [pl.col("signal").diff().fill_null(0).alias("position_change")]
+        signals = (
+            data.select([pl.col("Date"), pl.col("Close")])
+            .lazy()
+            .with_columns(
+                [
+                    pl.col("Close")
+                    .rolling_mean(
+                        window_size=self.window,
+                        min_samples=self.window,
+                    )
+                    .alias("mean"),
+                    pl.col("Close")
+                    .rolling_std(
+                        window_size=self.window,
+                        min_samples=self.window,
+                    )
+                    .alias("std"),
+                ]
+            )
+            # Avoid division by zero by replacing 0s with NaN.
+            .with_columns(
+                [
+                    pl.when(pl.col("std") == 0)
+                    .then(pl.lit(float("nan")))
+                    .otherwise(pl.col("std"))
+                    .alias("std")
+                ]
+            )
+            .with_columns(
+                [
+                    (pl.col("mean") + (self.std_dev * pl.col("std"))).alias(
+                        "upper_band"
+                    ),
+                    (pl.col("mean") - (self.std_dev * pl.col("std"))).alias(
+                        "lower_band"
+                    ),
+                ]
+            )
+            .with_columns(
+                [
+                    # Buy signal
+                    pl.when(pl.col("Close") < pl.col("lower_band"))
+                    .then(1.0)
+                    # Sell signal
+                    .when(pl.col("Close") > pl.col("upper_band"))
+                    .then(-1.0)
+                    .otherwise(0.0)
+                    .alias("signal")
+                ]
+            )
+            .with_columns(
+                [pl.col("signal").diff().fill_null(0).alias("position_change")]
+            )
+            .collect()
         )
 
         return signals

--- a/src/quant_trading_strategy_backtester/strategies/mean_reversion.py
+++ b/src/quant_trading_strategy_backtester/strategies/mean_reversion.py
@@ -61,7 +61,7 @@ class MeanReversionStrategy(BaseStrategy):
                 ]
             )
 
-        signals = (
+        signals: pl.DataFrame = (  # type: ignore[invalid-assignment]
             data.select([pl.col("Date"), pl.col("Close")])
             .lazy()
             .with_columns(

--- a/src/quant_trading_strategy_backtester/strategies/moving_average_crossover.py
+++ b/src/quant_trading_strategy_backtester/strategies/moving_average_crossover.py
@@ -56,7 +56,7 @@ class MovingAverageCrossoverStrategy(BaseStrategy):
                 ]
             )
 
-        signals = (
+        signals: pl.DataFrame = (  # type: ignore[invalid-assignment]
             data.select([pl.col("Date"), pl.col("Close")])
             .lazy()
             .with_columns(

--- a/src/quant_trading_strategy_backtester/strategies/moving_average_crossover.py
+++ b/src/quant_trading_strategy_backtester/strategies/moving_average_crossover.py
@@ -56,38 +56,40 @@ class MovingAverageCrossoverStrategy(BaseStrategy):
                 ]
             )
 
-        signals = data.select([pl.col("Date"), pl.col("Close")])
-        signals = signals.with_columns(
-            [
-                pl.col("Close")
-                .rolling_mean(
-                    window_size=self.short_window, min_samples=self.short_window
-                )
-                .alias("short_mavg"),
-                pl.col("Close")
-                .rolling_mean(
-                    window_size=self.long_window, min_samples=self.long_window
-                )
-                .alias("long_mavg"),
-                pl.lit(0.0).alias("signal"),
-            ]
-        )
-
-        signals = signals.with_columns(
-            [
-                # If the short-term moving average is above the long-term moving
-                # average, generate a buy signal.
-                pl.when(pl.col("short_mavg") > pl.col("long_mavg"))
-                .then(1.0)
-                .otherwise(0.0)
-                .alias("signal")
-            ]
-        )
-
-        # If the short-term moving average is below the long-term moving
-        # average, generate a sell signal by setting all non-buy signals to -1.
-        signals = signals.with_columns(
-            [pl.col("signal").diff().fill_null(0.0).alias("position_change")]
+        signals = (
+            data.select([pl.col("Date"), pl.col("Close")])
+            .lazy()
+            .with_columns(
+                [
+                    pl.col("Close")
+                    .rolling_mean(
+                        window_size=self.short_window,
+                        min_samples=self.short_window,
+                    )
+                    .alias("short_mavg"),
+                    pl.col("Close")
+                    .rolling_mean(
+                        window_size=self.long_window,
+                        min_samples=self.long_window,
+                    )
+                    .alias("long_mavg"),
+                    pl.lit(0.0).alias("signal"),
+                ]
+            )
+            .with_columns(
+                [
+                    # If the short-term moving average is above the long-term
+                    # moving average, generate a buy signal.
+                    pl.when(pl.col("short_mavg") > pl.col("long_mavg"))
+                    .then(1.0)
+                    .otherwise(0.0)
+                    .alias("signal")
+                ]
+            )
+            .with_columns(
+                [pl.col("signal").diff().fill_null(0.0).alias("position_change")]
+            )
+            .collect()
         )
 
         return signals

--- a/src/quant_trading_strategy_backtester/strategies/pairs_trading.py
+++ b/src/quant_trading_strategy_backtester/strategies/pairs_trading.py
@@ -76,7 +76,7 @@ class PairsTradingStrategy(BaseStrategy):
         if "Close_1" not in data.columns or "Close_2" not in data.columns:
             raise ValueError("Data must contain 'Close_1' and 'Close_2' columns")
 
-        signals = (
+        signals: pl.DataFrame = (  # type: ignore[invalid-assignment]
             data.select(
                 [
                     pl.col("Date"),

--- a/src/quant_trading_strategy_backtester/strategies/pairs_trading.py
+++ b/src/quant_trading_strategy_backtester/strategies/pairs_trading.py
@@ -76,59 +76,67 @@ class PairsTradingStrategy(BaseStrategy):
         if "Close_1" not in data.columns or "Close_2" not in data.columns:
             raise ValueError("Data must contain 'Close_1' and 'Close_2' columns")
 
-        signals = data.select(
-            [
-                pl.col("Date"),
-                pl.col("Close_1"),
-                pl.col("Close_2"),
-                (pl.col("Close_1") - pl.col("Close_2")).alias("spread"),
-            ]
-        )
-
-        # Calculate rolling mean and std, handling potential division by zero
-        signals = signals.with_columns(
-            [
-                pl.col("spread")
-                .rolling_mean(window_size=self.window, min_samples=self.window)
-                .alias("spread_mean"),
-                pl.col("spread")
-                .rolling_std(window_size=self.window, min_samples=self.window)
-                .alias("spread_std"),
-            ]
-        )
-
-        # Calculate z-score, avoiding division by zero
-        signals = signals.with_columns(
-            [
-                pl.when(pl.col("spread_std") != 0)
-                .then((pl.col("spread") - pl.col("spread_mean")) / pl.col("spread_std"))
-                .otherwise(0)
-                .alias("z_score")
-            ]
-        )
-
-        # Generate trading signals
-        signals = signals.with_columns(
-            [
-                pl.when(pl.col("z_score") > self.entry_z_score)
-                .then(-1)
-                .when(pl.col("z_score") < -self.entry_z_score)
-                .then(1)
-                .when(pl.col("z_score").abs() < self.exit_z_score)
-                .then(0)
-                .otherwise(None)
-                .alias("signal")
-            ]
-        )
-
-        # Fill forward the signal
-        signals = signals.with_columns(
-            [pl.col("signal").forward_fill().fill_null(0).alias("signal")]
-        )
-
-        # Calculate position changes
-        signals = signals.with_columns(
-            [pl.col("signal").diff().fill_null(0).alias("position_change")]
+        signals = (
+            data.select(
+                [
+                    pl.col("Date"),
+                    pl.col("Close_1"),
+                    pl.col("Close_2"),
+                    (pl.col("Close_1") - pl.col("Close_2")).alias("spread"),
+                ]
+            )
+            .lazy()
+            # Calculate rolling mean and std.
+            .with_columns(
+                [
+                    pl.col("spread")
+                    .rolling_mean(
+                        window_size=self.window,
+                        min_samples=self.window,
+                    )
+                    .alias("spread_mean"),
+                    pl.col("spread")
+                    .rolling_std(
+                        window_size=self.window,
+                        min_samples=self.window,
+                    )
+                    .alias("spread_std"),
+                ]
+            )
+            # Calculate z-score, avoiding division by zero.
+            .with_columns(
+                [
+                    pl.when(pl.col("spread_std") != 0)
+                    .then(
+                        (pl.col("spread") - pl.col("spread_mean"))
+                        / pl.col("spread_std")
+                    )
+                    .otherwise(0)
+                    .alias("z_score")
+                ]
+            )
+            # Generate trading signals.
+            .with_columns(
+                [
+                    pl.when(pl.col("z_score") > self.entry_z_score)
+                    .then(-1)
+                    .when(pl.col("z_score") < -self.entry_z_score)
+                    .then(1)
+                    .when(pl.col("z_score").abs() < self.exit_z_score)
+                    .then(0)
+                    .otherwise(None)
+                    .alias("signal")
+                ]
+            )
+            # Fill forward the signal.
+            .with_columns(
+                [pl.col("signal").forward_fill().fill_null(0).alias("signal")]
+            )
+            # Calculate position changes.
+            .with_columns(
+                [pl.col("signal").diff().fill_null(0).alias("position_change")]
+            )
+            .collect()
         )
 
         return signals

--- a/src/quant_trading_strategy_backtester/streamlit_ui.py
+++ b/src/quant_trading_strategy_backtester/streamlit_ui.py
@@ -25,9 +25,7 @@ def get_user_inputs_except_strategy_params() -> tuple[
         type, and a boolean indicating whether to use automatic ticker
         selection for pairs trading or buy and hold.
     """
-    strategy_type = st.sidebar.selectbox(
-        "Strategy Type", TRADING_STRATEGIES, index=0
-    )
+    strategy_type = st.sidebar.selectbox("Strategy Type", TRADING_STRATEGIES, index=0)
 
     auto_select_tickers = False
     # Two ticker strategies
@@ -62,12 +60,8 @@ def get_user_inputs_except_strategy_params() -> tuple[
     else:
         ticker = st.sidebar.text_input("Ticker Symbol", value="AAPL").upper()
 
-    start_date = st.sidebar.date_input(
-        "Start Date", value=datetime.date(2020, 1, 1)
-    )
-    end_date = st.sidebar.date_input(
-        "End Date", value=datetime.date(2023, 12, 31)
-    )
+    start_date = st.sidebar.date_input("Start Date", value=datetime.date(2020, 1, 1))
+    end_date = st.sidebar.date_input("End Date", value=datetime.date(2023, 12, 31))
 
     return ticker, start_date, end_date, strategy_type, auto_select_tickers
 

--- a/src/quant_trading_strategy_backtester/streamlit_ui.py
+++ b/src/quant_trading_strategy_backtester/streamlit_ui.py
@@ -4,7 +4,7 @@ interface.
 """
 
 import datetime
-from typing import Any, cast
+from typing import Any
 
 import streamlit as st
 from quant_trading_strategy_backtester.strategies.base import TRADING_STRATEGIES
@@ -25,8 +25,8 @@ def get_user_inputs_except_strategy_params() -> tuple[
         type, and a boolean indicating whether to use automatic ticker
         selection for pairs trading or buy and hold.
     """
-    strategy_type = cast(
-        str, st.sidebar.selectbox("Strategy Type", TRADING_STRATEGIES, index=0)
+    strategy_type = st.sidebar.selectbox(
+        "Strategy Type", TRADING_STRATEGIES, index=0
     )
 
     auto_select_tickers = False
@@ -62,13 +62,11 @@ def get_user_inputs_except_strategy_params() -> tuple[
     else:
         ticker = st.sidebar.text_input("Ticker Symbol", value="AAPL").upper()
 
-    start_date: datetime.date = cast(
-        datetime.date,
-        st.sidebar.date_input("Start Date", value=datetime.date(2020, 1, 1)),
+    start_date = st.sidebar.date_input(
+        "Start Date", value=datetime.date(2020, 1, 1)
     )
-    end_date: datetime.date = cast(
-        datetime.date,
-        st.sidebar.date_input("End Date", value=datetime.date(2023, 12, 31)),
+    end_date = st.sidebar.date_input(
+        "End Date", value=datetime.date(2023, 12, 31)
     )
 
     return ticker, start_date, end_date, strategy_type, auto_select_tickers

--- a/src/quant_trading_strategy_backtester/visualisation.py
+++ b/src/quant_trading_strategy_backtester/visualisation.py
@@ -92,7 +92,7 @@ def display_returns_by_month(results: pl.DataFrame) -> None:
         st.write("No data available for monthly performance calculation.")
         return
 
-    monthly_returns = (
+    monthly_returns: pl.DataFrame = (  # type: ignore[invalid-assignment]
         results.lazy()
         .with_columns(pl.col("Date").dt.strftime("%Y-%m").alias("Month (YYYY-MM)"))
         .group_by("Month (YYYY-MM)")
@@ -117,7 +117,7 @@ def display_returns_by_month(results: pl.DataFrame) -> None:
         st.write("No monthly data available after aggregation.")
     else:
         initial_start_value = monthly_returns["start_value"][0]
-        monthly_returns = (
+        monthly_returns: pl.DataFrame = (  # type: ignore[invalid-assignment]
             monthly_returns.lazy()
             .with_columns(
                 ((pl.col("end_value") / initial_start_value - 1) * 100).alias(

--- a/src/quant_trading_strategy_backtester/visualisation.py
+++ b/src/quant_trading_strategy_backtester/visualisation.py
@@ -93,9 +93,8 @@ def display_returns_by_month(results: pl.DataFrame) -> None:
         return
 
     monthly_returns = (
-        results.with_columns(
-            pl.col("Date").dt.strftime("%Y-%m").alias("Month (YYYY-MM)")
-        )
+        results.lazy()
+        .with_columns(pl.col("Date").dt.strftime("%Y-%m").alias("Month (YYYY-MM)"))
         .group_by("Month (YYYY-MM)")
         .agg(
             [
@@ -111,24 +110,27 @@ def display_returns_by_month(results: pl.DataFrame) -> None:
             ).alias("Monthly Return (%)")
         )
         .sort("Month (YYYY-MM)")
+        .collect()
     )
 
     if monthly_returns.is_empty():
         st.write("No monthly data available after aggregation.")
     else:
         initial_start_value = monthly_returns["start_value"][0]
-        # Calculate rolling returns
-        monthly_returns = monthly_returns.with_columns(
-            ((pl.col("end_value") / initial_start_value - 1) * 100).alias(
-                "Rolling Return (%)"
+        monthly_returns = (
+            monthly_returns.lazy()
+            .with_columns(
+                ((pl.col("end_value") / initial_start_value - 1) * 100).alias(
+                    "Rolling Return (%)"
+                )
             )
-        )
-        # Round the percentage columns
-        monthly_returns = monthly_returns.with_columns(
-            [
-                pl.col("Monthly Return (%)").round(2),
-                pl.col("Rolling Return (%)").round(2),
-            ]
+            .with_columns(
+                [
+                    pl.col("Monthly Return (%)").round(2),
+                    pl.col("Rolling Return (%)").round(2),
+                ]
+            )
+            .collect()
         )
         # Display the table
         st.dataframe(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.13.*"
 
 [[package]]
@@ -234,6 +234,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/2f/28592176381b9ab2cafa12829ba7b472d177f3acc35d8fbcf3673d966fff/greenlet-3.3.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:a1e41a81c7e2825822f4e068c48cb2196002362619e2d70b148f20a831c00739", size = 275140, upload-time = "2025-12-04T14:23:01.282Z" },
     { url = "https://files.pythonhosted.org/packages/2c/80/fbe937bf81e9fca98c981fe499e59a3f45df2a04da0baa5c2be0dca0d329/greenlet-3.3.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f515a47d02da4d30caaa85b69474cec77b7929b2e936ff7fb853d42f4bf8808", size = 599219, upload-time = "2025-12-04T14:50:08.309Z" },
     { url = "https://files.pythonhosted.org/packages/c2/ff/7c985128f0514271b8268476af89aee6866df5eec04ac17dcfbc676213df/greenlet-3.3.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d2d9fd66bfadf230b385fdc90426fcd6eb64db54b40c495b72ac0feb5766c54", size = 610211, upload-time = "2025-12-04T14:57:43.968Z" },
+    { url = "https://files.pythonhosted.org/packages/79/07/c47a82d881319ec18a4510bb30463ed6891f2ad2c1901ed5ec23d3de351f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30a6e28487a790417d036088b3bcb3f3ac7d8babaa7d0139edbaddebf3af9492", size = 624311, upload-time = "2025-12-04T15:07:14.697Z" },
     { url = "https://files.pythonhosted.org/packages/fd/8e/424b8c6e78bd9837d14ff7df01a9829fc883ba2ab4ea787d4f848435f23f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:087ea5e004437321508a8d6f20efc4cfec5e3c30118e1417ea96ed1d93950527", size = 612833, upload-time = "2025-12-04T14:26:03.669Z" },
     { url = "https://files.pythonhosted.org/packages/b5/ba/56699ff9b7c76ca12f1cdc27a886d0f81f2189c3455ff9f65246780f713d/greenlet-3.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab97cf74045343f6c60a39913fa59710e4bd26a536ce7ab2397adf8b27e67c39", size = 1567256, upload-time = "2025-12-04T15:04:25.276Z" },
     { url = "https://files.pythonhosted.org/packages/1e/37/f31136132967982d698c71a281a8901daf1a8fbab935dce7c0cf15f942cc/greenlet-3.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5375d2e23184629112ca1ea89a53389dddbffcf417dad40125713d88eb5f96e8", size = 1636483, upload-time = "2025-12-04T14:27:30.804Z" },
@@ -754,7 +755,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "ruff", specifier = ">=0.14.13" },
-    { name = "ty", specifier = ">=0.0.12" },
+    { name = "ty", specifier = ">=0.0.21" },
     { name = "watchdog", specifier = ">=4.0.1,<5.0.0" },
 ]
 
@@ -965,27 +966,26 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.12"
+version = "0.0.21"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/78/ba1a4ad403c748fbba8be63b7e774a90e80b67192f6443d624c64fe4aaab/ty-0.0.12.tar.gz", hash = "sha256:cd01810e106c3b652a01b8f784dd21741de9fdc47bd595d02c122a7d5cefeee7", size = 4981303, upload-time = "2026-01-14T22:30:48.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/20/2ba8fd9493c89c41dfe9dbb73bc70a28b28028463bc0d2897ba8be36230a/ty-0.0.21.tar.gz", hash = "sha256:a4c2ba5d67d64df8fcdefd8b280ac1149d24a73dbda82fa953a0dff9d21400ed", size = 5297967, upload-time = "2026-03-06T01:57:13.809Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/8f/c21314d074dda5fb13d3300fa6733fd0d8ff23ea83a721818740665b6314/ty-0.0.12-py3-none-linux_armv6l.whl", hash = "sha256:eb9da1e2c68bd754e090eab39ed65edf95168d36cbeb43ff2bd9f86b4edd56d1", size = 9614164, upload-time = "2026-01-14T22:30:44.016Z" },
-    { url = "https://files.pythonhosted.org/packages/09/28/f8a4d944d13519d70c486e8f96d6fa95647ac2aa94432e97d5cfec1f42f6/ty-0.0.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c181f42aa19b0ed7f1b0c2d559980b1f1d77cc09419f51c8321c7ddf67758853", size = 9542337, upload-time = "2026-01-14T22:30:05.687Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/9c/f576e360441de7a8201daa6dc4ebc362853bc5305e059cceeb02ebdd9a48/ty-0.0.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1f829e1eecd39c3e1b032149db7ae6a3284f72fc36b42436e65243a9ed1173db", size = 8909582, upload-time = "2026-01-14T22:30:46.089Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/13/0898e494032a5d8af3060733d12929e3e7716db6c75eac63fa125730a3e7/ty-0.0.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f45162e7826e1789cf3374627883cdeb0d56b82473a0771923e4572928e90be3", size = 9384932, upload-time = "2026-01-14T22:30:13.769Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/1a/b35b6c697008a11d4cedfd34d9672db2f0a0621ec80ece109e13fca4dfef/ty-0.0.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d11fec40b269bec01e751b2337d1c7ffa959a2c2090a950d7e21c2792442cccd", size = 9453140, upload-time = "2026-01-14T22:30:11.131Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/1e/71c9edbc79a3c88a0711324458f29c7dbf6c23452c6e760dc25725483064/ty-0.0.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09d99e37e761a4d2651ad9d5a610d11235fbcbf35dc6d4bc04abf54e7cf894f1", size = 9960680, upload-time = "2026-01-14T22:30:33.621Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/75/39375129f62dd22f6ad5a99cd2a42fd27d8b91b235ce2db86875cdad397d/ty-0.0.12-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d9ca0cdb17bd37397da7b16a7cd23423fc65c3f9691e453ad46c723d121225a1", size = 10904518, upload-time = "2026-01-14T22:30:08.464Z" },
-    { url = "https://files.pythonhosted.org/packages/32/5e/26c6d88fafa11a9d31ca9f4d12989f57782ec61e7291d4802d685b5be118/ty-0.0.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcf2757b905e7eddb7e456140066335b18eb68b634a9f72d6f54a427ab042c64", size = 10525001, upload-time = "2026-01-14T22:30:16.454Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/a5/2f0b91894af13187110f9ad7ee926d86e4e6efa755c9c88a820ed7f84c85/ty-0.0.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:00cf34c1ebe1147efeda3021a1064baa222c18cdac114b7b050bbe42deb4ca80", size = 10307103, upload-time = "2026-01-14T22:30:41.221Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/77/13d0410827e4bc713ebb7fdaf6b3590b37dcb1b82e0a81717b65548f2442/ty-0.0.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb3a655bd869352e9a22938d707631ac9fbca1016242b1f6d132d78f347c851", size = 10072737, upload-time = "2026-01-14T22:30:51.783Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/dd/fc36d8bac806c74cf04b4ca735bca14d19967ca84d88f31e121767880df1/ty-0.0.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4658e282c7cb82be304052f8f64f9925f23c3c4f90eeeb32663c74c4b095d7ba", size = 9368726, upload-time = "2026-01-14T22:30:18.683Z" },
-    { url = "https://files.pythonhosted.org/packages/54/70/9e8e461647550f83e2fe54bc632ccbdc17a4909644783cdbdd17f7296059/ty-0.0.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:c167d838eaaa06e03bb66a517f75296b643d950fbd93c1d1686a187e5a8dbd1f", size = 9454704, upload-time = "2026-01-14T22:30:22.759Z" },
-    { url = "https://files.pythonhosted.org/packages/04/9b/6292cf7c14a0efeca0539cf7d78f453beff0475cb039fbea0eb5d07d343d/ty-0.0.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2956e0c9ab7023533b461d8a0e6b2ea7b78e01a8dde0688e8234d0fce10c4c1c", size = 9649829, upload-time = "2026-01-14T22:30:31.234Z" },
-    { url = "https://files.pythonhosted.org/packages/49/bd/472a5d2013371e4870886cff791c94abdf0b92d43d305dd0f8e06b6ff719/ty-0.0.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5c6a3fd7479580009f21002f3828320621d8a82d53b7ba36993234e3ccad58c8", size = 10162814, upload-time = "2026-01-14T22:30:36.174Z" },
-    { url = "https://files.pythonhosted.org/packages/31/e9/2ecbe56826759845a7c21d80aa28187865ea62bc9757b056f6cbc06f78ed/ty-0.0.12-py3-none-win32.whl", hash = "sha256:a91c24fd75c0f1796d8ede9083e2c0ec96f106dbda73a09fe3135e075d31f742", size = 9140115, upload-time = "2026-01-14T22:30:38.903Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/6d/d9531eff35a5c0ec9dbc10231fac21f9dd6504814048e81d6ce1c84dc566/ty-0.0.12-py3-none-win_amd64.whl", hash = "sha256:df151894be55c22d47068b0f3b484aff9e638761e2267e115d515fcc9c5b4a4b", size = 9884532, upload-time = "2026-01-14T22:30:25.112Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/f3/20b49e75967023b123a221134548ad7000f9429f13fdcdda115b4c26305f/ty-0.0.12-py3-none-win_arm64.whl", hash = "sha256:cea99d334b05629de937ce52f43278acf155d3a316ad6a35356635f886be20ea", size = 9313974, upload-time = "2026-01-14T22:30:27.44Z" },
+    { url = "https://files.pythonhosted.org/packages/36/70/edf38bb37517531681d1c37f5df64744e5ad02673c02eb48447eae4bea08/ty-0.0.21-py3-none-linux_armv6l.whl", hash = "sha256:7bdf2f572378de78e1f388d24691c89db51b7caf07cf90f2bfcc1d6b18b70a76", size = 10299222, upload-time = "2026-03-06T01:57:16.64Z" },
+    { url = "https://files.pythonhosted.org/packages/72/62/0047b0bd19afeefbc7286f20a5f78a2aa39f92b4d89853f0d7185ab89edc/ty-0.0.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7e9613994610431ab8625025bd2880dbcb77c5c9fabdd21134cda12d840a529d", size = 10130513, upload-time = "2026-03-06T01:57:29.93Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/20/0b93a9e91aaed23155780258cdfdb4726ef68b6985378ac069bc427291a0/ty-0.0.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:56d3b198b64dd0a19b2b66e257deaed2ecea568e722ae5352f3c6fb62027f89d", size = 9605425, upload-time = "2026-03-06T01:57:27.115Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fd/9945e2fa2996a1287b1e1d7ce050e97e1f420233b271e770934bfa0880a0/ty-0.0.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d23d2c34f7a77d974bb08f0860ef700addc8a683d81a0319f71c08f87506cfd0", size = 10108298, upload-time = "2026-03-06T01:57:35.429Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e7/4ec52fcb15f3200826c9f048472c062549a05b0d1ef0b51f32d527b513c4/ty-0.0.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56b01fd2519637a4ca88344f61c96225f540c98ff18bca321d4eaa7bb0f7aa2f", size = 10121556, upload-time = "2026-03-06T01:57:03.242Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/c0/ad457be2a8abea0f25549598bd098554540ced66229488daa0d558dad3c8/ty-0.0.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e9de7e11c63c6afc40f3e9ba716374add171aee7fabc70b5146a510705c6d41b", size = 10603264, upload-time = "2026-03-06T01:56:52.134Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5b/2ecc7a2175243a4bcb72f5298ae41feabbb93b764bb0dc45722f3752c2c2/ty-0.0.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:62f7f5b235c4f7876db305c36997aea07b7af29b1a068f373d0e2547e25f32ff", size = 11196428, upload-time = "2026-03-06T01:57:32.94Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f5/aff507d6a901f328ef96a298032b0c11aaaf950a146ed7dd3b5bf2cd3acf/ty-0.0.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee8399f7c453a425291e6688efe430cfae7ab0ac4ffd50eba9f872bf878b54f6", size = 10866355, upload-time = "2026-03-06T01:56:57.831Z" },
+    { url = "https://files.pythonhosted.org/packages/be/30/822bbcb92d55b65989aa7ed06d9585f28ade9c9447369194ed4b0fb3b5b9/ty-0.0.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:210e7568c9f886c4d01308d751949ee714ad7ad9d7d928d2ba90d329dd880367", size = 10738177, upload-time = "2026-03-06T01:57:11.256Z" },
+    { url = "https://files.pythonhosted.org/packages/57/cc/46e7991b6469e93ac2c7e533a028983e402485580150ac864c56352a3a82/ty-0.0.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:53508e345b11569f78b21ba8e2b4e61df38a9754947fb3cd9f2ef574367338fb", size = 10079158, upload-time = "2026-03-06T01:57:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c2/0bbdadfbd008240f8f1a87dc877433cb3884436097926107ccf06e618199/ty-0.0.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:553e43571f4a35604c36cfd07d8b61a5eb7a714e3c67f8c4ff2cf674fefbaef9", size = 10150535, upload-time = "2026-03-06T01:57:08.815Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/2dbdb7b57b5362200ef0a39738ebd31331726328336def0143ac097ee59d/ty-0.0.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:666f6822e3b9200abfa7e95eb0ddd576460adb8d66b550c0ad2c70abc84a2048", size = 10319803, upload-time = "2026-03-06T01:57:19.106Z" },
+    { url = "https://files.pythonhosted.org/packages/72/84/70e52c0b7abc7c2086f9876ef454a73b161d3125315536d8d7e911c94ca4/ty-0.0.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a0854d008347ce4a5fb351af132f660a390ab2a1163444d075251d43e6f74b9b", size = 10826239, upload-time = "2026-03-06T01:57:21.727Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/8a/1f72480fd013bbc6cd1929002abbbcde9a0b08ead6a15154de9d7f7fa37e/ty-0.0.21-py3-none-win32.whl", hash = "sha256:bef3ab4c7b966bcc276a8ac6c11b63ba222d21355b48d471ea782c4104eee4e0", size = 9693196, upload-time = "2026-03-06T01:57:24.126Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f8/1104808b875c26c640e536945753a78562d606bef4e241d9dbf3d92477f6/ty-0.0.21-py3-none-win_amd64.whl", hash = "sha256:a709d576e5bea84b745d43058d8b9cd4f27f74a0b24acb4b0cbb7d3d41e0d050", size = 10668660, upload-time = "2026-03-06T01:56:55.06Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b8/25e0adc404bbf986977657b25318991f93097b49f8aea640d93c0b0db68e/ty-0.0.21-py3-none-win_arm64.whl", hash = "sha256:f72047996598ac20553fb7e21ba5741e3c82dee4e9eadf10d954551a5fe09391", size = 10104161, upload-time = "2026-03-06T01:57:06.072Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary

- Converted all Polars operations from eager to lazy evaluation using `.lazy()` ... `.collect()` chains across strategies, backtester, and visualisation
  - Signal generation in all four strategies (buy and hold, mean reversion, moving average crossover, pairs trading)
  - Return calculation in the backtester
  - Monthly returns aggregation in the visualisation module
- Fixed `ty` lint errors caused by `LazyFrame.collect()` returning `InProcessQuery | DataFrame` in the Polars type stubs
  - Added `pl.DataFrame` type annotations with `# type: ignore[invalid-assignment]` on all `.collect()` assignments
  - Upgraded `ty` from 0.0.12 to 0.0.21 to align CLI with VS Code extension
- Removed redundant `cast()` calls in `streamlit_ui.py` that `ty` flagged as unnecessary

## Related Issues

Fixes #33 