### PR TITLE
feat: Add walk-forward validation and trade markers; fix Streamlit performance caused by uncached backtest recomputation and excessive DB writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ _Try the deployed app
 - Support for multiple trading strategies with customisable parameters
 - Real-time data fetching from Yahoo Finance
 - Automatic optimisation of strategy parameters and stock selection from S&P 500
+- Walk-forward validation for parameter optimisation with expanding training
+  windows
+- Configurable transaction costs and slippage modelling
 - Visualisation of equity curves and strategy returns
 - Performance metrics including Total Return, Sharpe Ratio, and Max Drawdown
 - Monthly performance table with rolling returns

--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -45,6 +45,7 @@ from quant_trading_strategy_backtester.visualisation import (
     display_performance_metrics,
     display_returns_by_month,
     plot_equity_curve,
+    plot_pairs_spread,
     plot_strategy_returns,
 )
 
@@ -590,7 +591,20 @@ def main():
         st.session_state["_last_saved_key"] = _save_key
 
     display_performance_metrics(metrics, company_display)
-    plot_equity_curve(results, ticker_display, company_display)
+    plot_equity_curve(
+        results,
+        ticker_display,
+        company_display,
+        is_pairs=strategy_type == "Pairs Trading",
+    )
+    if strategy_type == "Pairs Trading":
+        plot_pairs_spread(
+            results,
+            ticker_display,
+            company_display,
+            entry_z_score=float(strategy_params.get("entry_z_score", 2.0)),
+            exit_z_score=float(strategy_params.get("exit_z_score", 0.5)),
+        )
     plot_strategy_returns(results, ticker_display, company_display)
     display_returns_by_month(results)
 

--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -30,10 +30,8 @@ from quant_trading_strategy_backtester.optimiser import (
     optimise_buy_and_hold_ticker,
     optimise_pairs_trading_tickers,
     optimise_single_ticker_strategy_ticker,
-    optimise_strategy_params,
     run_backtest,
     run_optimisation,
-    walk_forward_optimise,
 )
 from quant_trading_strategy_backtester.streamlit_ui import (
     get_user_inputs_except_strategy_params,
@@ -166,19 +164,15 @@ def prepare_single_ticker_strategy_with_optimisation(
     data = load_yfinance_data_one_ticker(best_ticker, start_date, end_date)
 
     # Optimise strategy parameters if requested.
-    if optimise and walk_forward:
-        best_params, _, _ = walk_forward_optimise(
+    if optimise:
+        best_params, _ = run_optimisation(
             data,
             strategy_type,
-            cast(dict[str, range | list[int | float]], strategy_params),
+            strategy_params,
+            start_date,
+            end_date,
             best_ticker,
-        )
-    elif optimise:
-        best_params, _ = optimise_strategy_params(
-            data,
-            strategy_type,
-            cast(dict[str, range | list[int | float]], strategy_params),
-            best_ticker,
+            walk_forward=walk_forward,
         )
     else:
         best_params = {

--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -17,7 +17,7 @@ from typing import Any, cast
 import polars as pl
 import streamlit as st
 
-from quant_trading_strategy_backtester.backtester import is_running_locally
+from quant_trading_strategy_backtester.backtester import Backtester, is_running_locally
 from quant_trading_strategy_backtester.data import (
     get_full_company_name,
     get_top_sp500_companies,
@@ -26,6 +26,7 @@ from quant_trading_strategy_backtester.data import (
 )
 from quant_trading_strategy_backtester.models import Session, StrategyModel
 from quant_trading_strategy_backtester.optimiser import (
+    create_strategy,
     optimise_buy_and_hold_ticker,
     optimise_pairs_trading_tickers,
     optimise_single_ticker_strategy_ticker,
@@ -47,6 +48,21 @@ from quant_trading_strategy_backtester.visualisation import (
     plot_equity_curve,
     plot_strategy_returns,
 )
+
+
+@st.cache_data
+def _cached_run_backtest(
+    data: pl.DataFrame,
+    strategy_type: str,
+    strategy_params: dict[str, Any],
+    tickers: str | list[str],
+) -> tuple[pl.DataFrame, dict]:
+    """
+    Cached wrapper for run_backtest to avoid recomputation on
+    Streamlit reruns.
+    """
+    return run_backtest(data, strategy_type, strategy_params, tickers)
+
 
 # Trading strategy preparation functions
 
@@ -532,7 +548,19 @@ def main():
         if strategy_type == "Pairs Trading"
         else ticker_display
     )
-    results, metrics = run_backtest(data, strategy_type, strategy_params, tickers)
+    results, metrics = _cached_run_backtest(
+        data, strategy_type, strategy_params, tickers
+    )
+
+    # Save only the final backtest result, and only once per unique
+    # combination of inputs (not on every Streamlit rerun).
+    _save_key = f"{strategy_type}:{strategy_params}:{tickers}"
+    if st.session_state.get("_last_saved_key") != _save_key:
+        strategy = create_strategy(strategy_type, strategy_params)
+        backtester = Backtester(data, strategy, tickers=tickers)
+        backtester.results = results
+        backtester.save_results()
+        st.session_state["_last_saved_key"] = _save_key
 
     display_performance_metrics(metrics, company_display)
     plot_equity_curve(results, ticker_display, company_display)

--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -33,6 +33,7 @@ from quant_trading_strategy_backtester.optimiser import (
     optimise_strategy_params,
     run_backtest,
     run_optimisation,
+    walk_forward_optimise,
 )
 from quant_trading_strategy_backtester.streamlit_ui import (
     get_user_inputs_except_strategy_params,
@@ -123,6 +124,7 @@ def prepare_single_ticker_strategy_with_optimisation(
     strategy_type: str,
     strategy_params: dict[str, Any],
     optimise: bool,
+    walk_forward: bool = False,
 ) -> tuple[pl.DataFrame, str, dict[str, Any]]:
     """
     Handles the optimisation process for single ticker strategies.
@@ -136,6 +138,7 @@ def prepare_single_ticker_strategy_with_optimisation(
         strategy_type: The type of strategy being used.
         strategy_params: Initial strategy parameters.
         optimise: Whether to optimise strategy parameters.
+        walk_forward: Whether to use walk-forward validation.
 
     Returns:
         A tuple containing:
@@ -162,8 +165,15 @@ def prepare_single_ticker_strategy_with_optimisation(
     # Load historical data for the selected ticker
     data = load_yfinance_data_one_ticker(best_ticker, start_date, end_date)
 
-    # Optimise strategy parameters if requested
-    if optimise:
+    # Optimise strategy parameters if requested.
+    if optimise and walk_forward:
+        best_params, _, _ = walk_forward_optimise(
+            data,
+            strategy_type,
+            cast(dict[str, range | list[int | float]], strategy_params),
+            best_ticker,
+        )
+    elif optimise:
         best_params, _ = optimise_strategy_params(
             data,
             strategy_type,
@@ -202,6 +212,7 @@ def prepare_pairs_trading_strategy_with_optimisation(
     end_date: datetime.date,
     strategy_params: dict[str, Any],
     optimise: bool,
+    walk_forward: bool = False,
 ) -> tuple[pl.DataFrame, str, dict[str, int | float]]:
     """
     Handles the optimisation process for pairs trading strategy.
@@ -214,6 +225,7 @@ def prepare_pairs_trading_strategy_with_optimisation(
         end_date: The end date for historical data.
         strategy_params: Initial strategy parameters.
         optimise: Whether to optimise strategy parameters.
+        walk_forward: Whether to use walk-forward validation.
 
     Returns:
         A tuple containing:
@@ -264,6 +276,7 @@ def prepare_pairs_trading_strategy_with_optimisation(
             start_date,
             end_date,
             [ticker1, ticker2],
+            walk_forward=walk_forward,
         )
 
     return data, ticker_display, strategy_params
@@ -275,6 +288,7 @@ def prepare_pairs_trading_strategy_without_optimisation(
     end_date: datetime.date,
     strategy_params: dict[str, Any],
     optimise: bool,
+    walk_forward: bool = False,
 ) -> tuple[pl.DataFrame, str, dict[str, Any]]:
     """
     Handles the pairs trading strategy for user-selected tickers.
@@ -288,6 +302,7 @@ def prepare_pairs_trading_strategy_without_optimisation(
         end_date: The end date for historical data.
         strategy_params: Initial strategy parameters.
         optimise: Whether to optimise strategy parameters.
+        walk_forward: Whether to use walk-forward validation.
 
     Returns:
         A tuple containing:
@@ -308,6 +323,7 @@ def prepare_pairs_trading_strategy_without_optimisation(
             start_date,
             end_date,
             [ticker1, ticker2],
+            walk_forward=walk_forward,
         )
 
     return data, ticker_display, strategy_params
@@ -320,6 +336,7 @@ def prepare_single_ticker_strategy(
     strategy_type: str,
     strategy_params: dict[str, Any],
     optimise: bool,
+    walk_forward: bool = False,
 ) -> tuple[pl.DataFrame, str, dict[str, Any]]:
     """
     Handles strategies for a single ticker.
@@ -334,6 +351,7 @@ def prepare_single_ticker_strategy(
         strategy_type: The type of strategy being used.
         strategy_params: Initial strategy parameters.
         optimise: Whether to optimise strategy parameters.
+        walk_forward: Whether to use walk-forward validation.
 
     Returns:
         A tuple containing:
@@ -347,7 +365,13 @@ def prepare_single_ticker_strategy(
 
     if optimise and strategy_type != "Buy and Hold":
         strategy_params, _ = run_optimisation(
-            data, strategy_type, strategy_params, start_date, end_date, ticker
+            data,
+            strategy_type,
+            strategy_params,
+            start_date,
+            end_date,
+            ticker,
+            walk_forward=walk_forward,
         )
     elif optimise and strategy_type == "Buy and Hold":
         top_companies = get_top_sp500_companies(NUM_TOP_COMPANIES_ONE_TICKER)
@@ -480,7 +504,9 @@ def main():
     ticker, start_date, end_date, strategy_type, auto_select_tickers = (
         get_user_inputs_except_strategy_params()
     )
-    optimise, strategy_params = get_user_inputs_for_strategy_params(strategy_type)
+    optimise, walk_forward, strategy_params = get_user_inputs_for_strategy_params(
+        strategy_type
+    )
 
     # Initialise company names
     company_name1 = None
@@ -490,7 +516,7 @@ def main():
     if strategy_type == "Pairs Trading" and auto_select_tickers:
         data, ticker_display, strategy_params = (
             prepare_pairs_trading_strategy_with_optimisation(
-                start_date, end_date, strategy_params, optimise
+                start_date, end_date, strategy_params, optimise, walk_forward
             )
         )
         # Update company names with the selected pair
@@ -505,6 +531,7 @@ def main():
                 end_date,
                 strategy_params,
                 optimise,
+                walk_forward,
             )
         )
         ticker1, ticker2 = cast(tuple[str, str], ticker)
@@ -517,7 +544,12 @@ def main():
     ):
         data, ticker_display, strategy_params = (
             prepare_single_ticker_strategy_with_optimisation(
-                start_date, end_date, strategy_type, strategy_params, optimise
+                start_date,
+                end_date,
+                strategy_type,
+                strategy_params,
+                optimise,
+                walk_forward,
             )
         )
         company_name1 = get_full_company_name(ticker_display)
@@ -529,6 +561,7 @@ def main():
             strategy_type,
             strategy_params,
             optimise,
+            walk_forward,
         )
         company_name1 = get_full_company_name(ticker_display)
 

--- a/src/quant_trading_strategy_backtester/backtester.py
+++ b/src/quant_trading_strategy_backtester/backtester.py
@@ -74,14 +74,14 @@ class Backtester:
         Runs the backtest.
 
         Generates trading signals using the strategy, calculates returns,
-        stores the results, and saves them to the database.
+        and stores the results. Call save_results() separately to persist
+        to the database.
 
         Returns:
             A DataFrame containing the backtest results.
         """
         signals = self.strategy.generate_signals(self.data)
         self.results = self._calculate_returns(signals)
-        self.save_results()
         return self.results
 
     def _calculate_returns(self, signals: pl.DataFrame) -> pl.DataFrame:

--- a/src/quant_trading_strategy_backtester/optimiser.py
+++ b/src/quant_trading_strategy_backtester/optimiser.py
@@ -42,6 +42,7 @@ def run_optimisation(
     start_date: datetime.date,
     end_date: datetime.date,
     tickers: str | list[str],
+    walk_forward: bool = False,
 ) -> tuple[dict[str, Any], dict[str, float]]:
     """
     Runs the optimisation process for strategy parameters or ticker selection.
@@ -53,6 +54,7 @@ def run_optimisation(
         start_date: Start date for historical data.
         end_date: End date for historical data.
         tickers: The ticker or tickers used in the backtest.
+        walk_forward: Whether to use walk-forward validation.
 
     Returns:
         A tuple containing:
@@ -68,6 +70,14 @@ def run_optimisation(
             top_companies, start_date, end_date
         )
         st.success(f"Best ticker for Buy and Hold: {best_ticker}")
+    elif walk_forward:
+        strategy_params, metrics, fold_results = walk_forward_optimise(
+            data,
+            strategy_type,
+            cast(dict[str, range | list[int | float]], strategy_params),
+            tickers,
+        )
+        _display_walk_forward_results(fold_results)
     else:
         strategy_params, metrics = optimise_strategy_params(
             data,
@@ -84,6 +94,33 @@ def run_optimisation(
     st.write(strategy_params)
 
     return strategy_params, metrics
+
+
+def _display_walk_forward_results(fold_results: list[dict]) -> None:
+    """
+    Display per-fold walk-forward validation results in the Streamlit
+    UI.
+
+    Args:
+        fold_results: List of per-fold result dictionaries from
+            walk_forward_optimise().
+    """
+    with st.expander("Walk-Forward Validation Details"):
+        for fold in fold_results:
+            st.subheader(f"Fold {fold['fold']}")
+            st.write(
+                f"Train: {fold['train_rows']} rows, Test: {fold['test_rows']} rows"
+            )
+            st.write(f"Best params: {fold['params']}")
+            col1, col2 = st.columns(2)
+            col1.metric(
+                "In-Sample Sharpe",
+                f"{fold['in_sample_sharpe']:.4f}",
+            )
+            col2.metric(
+                "Out-of-Sample Sharpe",
+                f"{fold['oos_metrics']['Sharpe Ratio']:.4f}",
+            )
 
 
 def optimise_buy_and_hold_ticker(

--- a/src/quant_trading_strategy_backtester/optimiser.py
+++ b/src/quant_trading_strategy_backtester/optimiser.py
@@ -338,6 +338,99 @@ def optimise_pairs_trading_tickers(
     return best_pair, best_params, best_metrics
 
 
+def walk_forward_optimise(
+    data: pl.DataFrame,
+    strategy_type: str,
+    parameter_ranges: dict[str, range | list[int | float]],
+    tickers: str | list[str],
+    n_folds: int = 5,
+) -> tuple[dict[str, int | float], dict[str, float], list[dict]]:
+    """
+    Optimises strategy parameters using walk-forward validation.
+
+    Splits data into (n_folds + 1) equal segments. For each fold, we use an
+    expanding training window for grid search and evaluate the best parameters
+    on the next segment. This tests parameter stability across time rather than
+    depending on a single split point.
+
+    Args:
+        data: Historical price data.
+        strategy_type: The type of strategy to optimise.
+        parameter_ranges: A dictionary of parameters and their
+            possible values to test.
+        tickers: The ticker or tickers used in the backtest.
+        n_folds: Number of out-of-sample test folds.
+
+    Returns:
+        A tuple containing:
+            - Best parameters from the final fold.
+            - Aggregated out-of-sample metrics (mean across folds).
+            - Per-fold results with params and metrics.
+    """
+    n_rows = len(data)
+    segment_size = n_rows // (n_folds + 1)
+    if segment_size < 2:
+        raise ValueError(
+            f"Not enough data for {n_folds} folds: "
+            f"{n_rows} rows, need at least {2 * (n_folds + 1)}"
+        )
+
+    param_names = list(parameter_ranges.keys())
+    param_values = [
+        list(v) if isinstance(v, range) else v for v in parameter_ranges.values()
+    ]
+    param_combinations = list(itertools.product(*param_values))
+
+    fold_results: list[dict] = []
+
+    for fold in range(n_folds):
+        train_end = segment_size * (fold + 1)
+        test_end = min(segment_size * (fold + 2), n_rows)
+        train_data = data[:train_end]
+        test_data = data[train_end:test_end]
+
+        # Grid search on training data.
+        best_sharpe = float("-inf")
+        best_params: dict[str, int | float] | None = None
+        for params in param_combinations:
+            current_params = dict(zip(param_names, params))
+            _, metrics = run_backtest(
+                train_data, strategy_type, current_params, tickers
+            )
+            if metrics["Sharpe Ratio"] > best_sharpe:
+                best_sharpe = metrics["Sharpe Ratio"]
+                best_params = current_params
+
+        if best_params is None:
+            raise ValueError(f"Walk-forward optimisation failed on fold {fold + 1}")
+
+        # Evaluate best params on out-of-sample test data.
+        _, oos_metrics = run_backtest(test_data, strategy_type, best_params, tickers)
+
+        fold_results.append(
+            {
+                "fold": fold + 1,
+                "train_rows": len(train_data),
+                "test_rows": len(test_data),
+                "params": best_params,
+                "in_sample_sharpe": best_sharpe,
+                "oos_metrics": oos_metrics,
+            }
+        )
+
+    # Aggregate out-of-sample metrics across folds.
+    metric_keys = fold_results[0]["oos_metrics"].keys()
+    aggregated_metrics = {
+        key: sum(f["oos_metrics"][key] for f in fold_results) / n_folds
+        for key in metric_keys
+    }
+
+    # Return best params from the final fold (largest training set).
+    final_params = fold_results[-1]["params"]
+
+    return final_params, aggregated_metrics, fold_results
+
+
 def run_backtest(
     data: pl.DataFrame,
     strategy_type: str,

--- a/src/quant_trading_strategy_backtester/streamlit_ui.py
+++ b/src/quant_trading_strategy_backtester/streamlit_ui.py
@@ -155,7 +155,7 @@ def get_fixed_params(strategy_type: str) -> dict[str, Any]:
 
 def get_user_inputs_for_strategy_params(
     strategy_type: str,
-) -> tuple[bool, dict[str, float] | dict[str, range] | dict[str, list[float]]]:
+) -> tuple[bool, bool, dict[str, float] | dict[str, range] | dict[str, list[float]]]:
     """
     Gets user inputs for the strategy parameters from the Streamlit sidebar
     based on the selected strategy.
@@ -167,13 +167,22 @@ def get_user_inputs_for_strategy_params(
         A tuple containing a boolean indicating whether to optimise, and a dictionary of strategy parameters.
     """
     if strategy_type == "Buy and Hold":
-        return False, {}  # No parameters for Buy and Hold strategy
+        return False, False, {}  # No parameters for Buy and Hold strategy
 
     optimise = st.sidebar.checkbox("Optimise Strategy Parameters")
+    walk_forward = False
 
     if optimise:
         params = get_optimisation_ranges(strategy_type)
+        walk_forward = st.sidebar.checkbox(
+            "Use Walk-Forward Validation",
+            help=(
+                "Split data into multiple folds and optimise on "
+                "each training window, then evaluate out-of-sample."
+                " Shows parameter stability over time."
+            ),
+        )
     else:
         params = get_fixed_params(strategy_type)
 
-    return optimise, params
+    return optimise, walk_forward, params

--- a/src/quant_trading_strategy_backtester/visualisation.py
+++ b/src/quant_trading_strategy_backtester/visualisation.py
@@ -25,24 +25,60 @@ def display_performance_metrics(
 
 
 def plot_equity_curve(
-    results: pl.DataFrame, ticker_display: str, company_name: str | None
+    results: pl.DataFrame,
+    ticker_display: str,
+    company_name: str | None,
+    is_pairs: bool = False,
 ) -> None:
     """
-    Plots the equity curve of the backtest.
+    Plots the equity curve with trade markers overlaid.
 
     Args:
         results: The backtest results DataFrame.
         ticker_display: The stock ticker symbol or pair to display.
         company_name: The full name of the company or companies.
+        is_pairs: Whether this is a pairs trading strategy. Changes
+            marker labels from Buy/Sell to Long/Short Spread.
     """
     st.subheader("Equity Curve")
-    fig = go.Figure(
-        data=go.Scatter(
+    fig = go.Figure()
+
+    fig.add_trace(
+        go.Scatter(
             x=results["Date"].to_list(),
             y=results["equity_curve"].to_list(),
             mode="lines",
+            name="Equity",
         )
     )
+
+    # Overlay trade markers where position changes.
+    long_label = "Long Spread" if is_pairs else "Buy"
+    short_label = "Short Spread" if is_pairs else "Sell"
+    buys = results.filter(pl.col("position_change") > 0)
+    sells = results.filter(pl.col("position_change") < 0)
+
+    if not buys.is_empty():
+        fig.add_trace(
+            go.Scatter(
+                x=buys["Date"].to_list(),
+                y=buys["equity_curve"].to_list(),
+                mode="markers",
+                marker=dict(size=6, color="green", opacity=0.7),
+                name=long_label,
+            )
+        )
+    if not sells.is_empty():
+        fig.add_trace(
+            go.Scatter(
+                x=sells["Date"].to_list(),
+                y=sells["equity_curve"].to_list(),
+                mode="markers",
+                marker=dict(size=6, color="red", opacity=0.7),
+                name=short_label,
+            )
+        )
+
     fig.update_layout(
         title=f"{company_name} ({ticker_display}) Equity Curve",
         xaxis_title="Date",
@@ -75,6 +111,91 @@ def plot_strategy_returns(
         xaxis_title="Date",
         yaxis_title="Returns (%)",
         yaxis_tickformat=".2f",  # Format y-axis ticks to 2 decimal places
+    )
+    st.plotly_chart(fig)
+
+
+def plot_pairs_spread(
+    results: pl.DataFrame,
+    ticker_display: str,
+    company_name: str | None,
+    entry_z_score: float,
+    exit_z_score: float,
+) -> None:
+    """
+    Plot the z-score of the pairs spread with entry/exit threshold
+    bands and position markers.
+
+    Args:
+        results: The backtest results DataFrame (must contain
+            'z_score' and 'signal' columns).
+        ticker_display: The stock ticker pair to display.
+        company_name: The full name of the companies.
+        entry_z_score: The z-score threshold for entering a trade.
+        exit_z_score: The z-score threshold for exiting a trade.
+    """
+    if "z_score" not in results.columns:
+        return
+
+    st.subheader("Pairs Spread Z-Score")
+    dates = results["Date"].to_list()
+    z_scores = results["z_score"].to_list()
+
+    fig = go.Figure()
+
+    fig.add_trace(
+        go.Scatter(
+            x=dates,
+            y=z_scores,
+            mode="lines",
+            name="Z-Score",
+        )
+    )
+
+    # Entry/exit threshold bands.
+    for val, label, dash in [
+        (entry_z_score, f"Entry ({entry_z_score})", "dash"),
+        (-entry_z_score, f"Entry ({-entry_z_score})", "dash"),
+        (exit_z_score, f"Exit ({exit_z_score})", "dot"),
+        (-exit_z_score, f"Exit ({-exit_z_score})", "dot"),
+    ]:
+        fig.add_hline(
+            y=val,
+            line_dash=dash,
+            line_color="grey",
+            opacity=0.6,
+            annotation_text=label,
+        )
+
+    # Mark position changes on the z-score line.
+    buys = results.filter(pl.col("position_change") > 0)
+    sells = results.filter(pl.col("position_change") < 0)
+
+    if not buys.is_empty():
+        fig.add_trace(
+            go.Scatter(
+                x=buys["Date"].to_list(),
+                y=buys["z_score"].to_list(),
+                mode="markers",
+                marker=dict(size=6, color="green", opacity=0.7),
+                name="Long Spread",
+            )
+        )
+    if not sells.is_empty():
+        fig.add_trace(
+            go.Scatter(
+                x=sells["Date"].to_list(),
+                y=sells["z_score"].to_list(),
+                mode="markers",
+                marker=dict(size=6, color="red", opacity=0.7),
+                name="Short Spread",
+            )
+        )
+
+    fig.update_layout(
+        title=(f"{company_name} ({ticker_display}) Pairs Spread Z-Score"),
+        xaxis_title="Date",
+        yaxis_title="Z-Score",
     )
     st.plotly_chart(fig)
 

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -212,6 +212,7 @@ def test_backtester_save_results(mock_db_session, mock_polars_data):
     strategy = MovingAverageCrossoverStrategy({"short_window": 5, "long_window": 20})
     backtester = Backtester(mock_polars_data, strategy, session=mock_db_session)
     backtester.run()
+    backtester.save_results()
 
     # Print metrics for debugging
     metrics = backtester.get_performance_metrics()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -50,7 +50,7 @@ def test_load_yfinance_data_two_tickers(
             }
         )
         multi_index_data.columns = pd.MultiIndex.from_tuples(
-            list(multi_index_data.columns)
+            list(multi_index_data.columns)  # type: ignore[invalid-argument-type]
         )
         return multi_index_data
 

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -435,7 +435,7 @@ def test_prepare_single_ticker_strategy_with_optimisation(monkeypatch):
     def mock_load_data(*args, **kwargs):
         return mock_polars_data
 
-    def mock_optimise_strategy_params(*args, **kwargs):
+    def mock_run_optimisation(*args, **kwargs):
         return {"short_window": 15, "long_window": 60}, {"Sharpe Ratio": 1.8}
 
     monkeypatch.setattr(
@@ -451,8 +451,8 @@ def test_prepare_single_ticker_strategy_with_optimisation(monkeypatch):
         mock_load_data,
     )
     monkeypatch.setattr(
-        "quant_trading_strategy_backtester.app.optimise_strategy_params",
-        mock_optimise_strategy_params,
+        "quant_trading_strategy_backtester.app.run_optimisation",
+        mock_run_optimisation,
     )
 
     start_date = datetime.date(2020, 1, 1)

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -18,6 +18,7 @@ from quant_trading_strategy_backtester.optimiser import (
     optimise_single_ticker_strategy_ticker,
     run_backtest,
     run_optimisation,
+    walk_forward_optimise,
 )
 
 
@@ -532,3 +533,70 @@ def test_prepare_single_ticker_strategy_with_optimisation_no_param_optimisation(
     assert ticker_display == "AAPL"
     assert isinstance(final_params, dict)
     assert final_params == strategy_params  # Parameters should remain unchanged
+
+
+def test_walk_forward_optimise():
+    """
+    Verify that walk-forward optimisation returns per-fold results with
+    out-of-sample metrics and stable structure.
+    """
+    # 60 rows gives 10 rows per segment with n_folds=5.
+    dates = [datetime.date(2020, 1, 1) + datetime.timedelta(days=i) for i in range(60)]
+    closes = [100.0 + i * 0.5 for i in range(60)]
+    data = pl.DataFrame({"Date": dates, "Close": closes})
+
+    parameter_ranges: dict[str, range | list[int | float]] = {
+        "short_window": [3, 5],
+        "long_window": [10, 15],
+    }
+
+    best_params, agg_metrics, fold_results = walk_forward_optimise(
+        data,
+        "Moving Average Crossover",
+        parameter_ranges,
+        tickers="TEST",
+        n_folds=3,
+    )
+
+    # Check structure.
+    assert isinstance(best_params, dict)
+    assert set(best_params.keys()) == {"short_window", "long_window"}
+    assert isinstance(agg_metrics, dict)
+    assert "Total Return" in agg_metrics
+    assert "Sharpe Ratio" in agg_metrics
+    assert "Max Drawdown" in agg_metrics
+    assert len(fold_results) == 3
+
+    # Each fold should have the expected keys.
+    for fold in fold_results:
+        assert "fold" in fold
+        assert "train_rows" in fold
+        assert "test_rows" in fold
+        assert "params" in fold
+        assert "in_sample_sharpe" in fold
+        assert "oos_metrics" in fold
+
+    # Training window should expand across folds.
+    assert fold_results[0]["train_rows"] < fold_results[1]["train_rows"]
+    assert fold_results[1]["train_rows"] < fold_results[2]["train_rows"]
+
+    # Best params should come from the final fold.
+    assert best_params == fold_results[-1]["params"]
+
+
+def test_walk_forward_optimise_insufficient_data():
+    """
+    Verify that walk-forward raises ValueError when data is too small
+    for the requested number of folds.
+    """
+    dates = [datetime.date(2020, 1, 1) + datetime.timedelta(days=i) for i in range(5)]
+    data = pl.DataFrame({"Date": dates, "Close": [100.0 + i for i in range(5)]})
+
+    with pytest.raises(ValueError, match="Not enough data"):
+        walk_forward_optimise(
+            data,
+            "Moving Average Crossover",
+            {"short_window": [3], "long_window": [10]},
+            tickers="TEST",
+            n_folds=5,
+        )


### PR DESCRIPTION
# Summary

- Added walk-forward validation with expanding training windows for parameter optimisation
  - Grid searches each fold's training data, evaluates best params out-of-sample, returns params from the final fold
  - Accessible via a 'Use Walk-Forward Validation' checkbox under the optimise toggle, with per-fold details in an expander
- Added buy/sell trade markers to the equity curve for all strategies
  - Green/red dots at position changes, with labels adapted for pairs trading ('Long Spread' / 'Short Spread')
  - New z-score chart for pairs trading with entry/exit threshold bands and trade markers
- Fixed Streamlit app slowness from uncached backtest recomputation and excessive DB writes
  - `Backtester.run()` was calling `save_results()` on every invocation, including every parameter combination during optimisation (accumulated thousands of rows)
  - Backtest results are now cached with `@st.cache_data`; only the final result is persisted, gated by session state
- Routed all prepare functions through `run_optimisation()` for consistent walk-forward UI display

## Related Issues

- Fixes #8 
- Fixes #46

## Screenshots

<img width="1479" height="1239" alt="image" src="https://github.com/user-attachments/assets/907a7dbf-cff6-4824-a401-e9d602f6bc6e" />
<img width="1479" height="1305" alt="image" src="https://github.com/user-attachments/assets/0c9b6036-6603-4ad2-8be4-ac0e31605b94" />
<img width="774" height="1236" alt="image" src="https://github.com/user-attachments/assets/12a7eef7-9064-49a8-9736-a913075e2ea2" />
