### PR TITLE
fix: Correct core backtest trade semantics

### DIFF
--- a/src/quant_trading_strategy_backtester/strategies/buy_and_hold.py
+++ b/src/quant_trading_strategy_backtester/strategies/buy_and_hold.py
@@ -21,9 +21,10 @@ class BuyAndHoldStrategy(BaseStrategy):
         super().__init__(params)
 
     def generate_signals(self, data: pl.DataFrame) -> pl.DataFrame:
-        """
-        Generates trading signals for the Buy and Hold strategy. Creates a
-        column of 1s to indicate a constant long position.
+        """Generate trading signals for the Buy and Hold strategy.
+
+        Create a constant long position with a single position change on the
+        first row, so costs are charged once when the strategy enters.
 
         Args:
             data: Historical price data.
@@ -43,13 +44,18 @@ class BuyAndHoldStrategy(BaseStrategy):
 
         signals: pl.DataFrame = (  # type: ignore[invalid-assignment]
             data.select([pl.col("Date"), pl.col("Close")])
+            .with_row_index()
             .lazy()
             .with_columns(
                 [
                     pl.lit(1.0).alias("signal"),
-                    pl.lit(1.0).alias("position_change"),
+                    pl.when(pl.col("index") == 0)
+                    .then(1.0)
+                    .otherwise(0.0)
+                    .alias("position_change"),
                 ]
             )
+            .drop("index")
             .collect()
         )
 

--- a/src/quant_trading_strategy_backtester/strategies/mean_reversion.py
+++ b/src/quant_trading_strategy_backtester/strategies/mean_reversion.py
@@ -61,6 +61,11 @@ class MeanReversionStrategy(BaseStrategy):
                 ]
             )
 
+        valid_band = (
+            pl.col("std").is_not_null()
+            & pl.col("std").is_finite()
+            & (pl.col("std") > 0)
+        )
         signals: pl.DataFrame = (  # type: ignore[invalid-assignment]
             data.select([pl.col("Date"), pl.col("Close")])
             .lazy()
@@ -80,15 +85,6 @@ class MeanReversionStrategy(BaseStrategy):
                     .alias("std"),
                 ]
             )
-            # Avoid division by zero by replacing 0s with NaN.
-            .with_columns(
-                [
-                    pl.when(pl.col("std") == 0)
-                    .then(pl.lit(float("nan")))
-                    .otherwise(pl.col("std"))
-                    .alias("std")
-                ]
-            )
             .with_columns(
                 [
                     (pl.col("mean") + (self.std_dev * pl.col("std"))).alias(
@@ -101,11 +97,11 @@ class MeanReversionStrategy(BaseStrategy):
             )
             .with_columns(
                 [
-                    # Buy signal
-                    pl.when(pl.col("Close") < pl.col("lower_band"))
+                    # Buy signal.
+                    pl.when(valid_band & (pl.col("Close") < pl.col("lower_band")))
                     .then(1.0)
-                    # Sell signal
-                    .when(pl.col("Close") > pl.col("upper_band"))
+                    # Sell signal.
+                    .when(valid_band & (pl.col("Close") > pl.col("upper_band")))
                     .then(-1.0)
                     .otherwise(0.0)
                     .alias("signal")

--- a/tests/strategies/test_buy_and_hold.py
+++ b/tests/strategies/test_buy_and_hold.py
@@ -8,6 +8,10 @@ import polars as pl
 from quant_trading_strategy_backtester.strategies.buy_and_hold import BuyAndHoldStrategy
 
 
+def assert_single_entry_trade(signals: pl.DataFrame) -> None:
+    assert signals["position_change"].to_list() == [1.0] + [0.0] * (len(signals) - 1)
+
+
 def test_buy_and_hold_strategy_initialisation() -> None:
     params = {}  # Buy and Hold doesn't require parameters
     strategy = BuyAndHoldStrategy(params)
@@ -22,7 +26,7 @@ def test_buy_and_hold_strategy_generate_signals(mock_polars_data: pl.DataFrame) 
     EXPECTED_COLS = {"Date", "Close", "signal", "position_change"}
     assert all(col in signals.columns for col in EXPECTED_COLS)
     assert (signals["signal"] == 1).all(), "All signals should be 1 (buy)"
-    assert (signals["position_change"] == 1).all(), "All position_change should be 1"
+    assert_single_entry_trade(signals)
 
 
 def test_buy_and_hold_strategy_with_mock_data():
@@ -41,7 +45,7 @@ def test_buy_and_hold_strategy_with_mock_data():
 
     # Check if signals are generated correctly
     assert signals["signal"].sum() == len(signals), "All signals should be buy (1)"
-    assert (signals["position_change"] == 1).all(), "All position_change should be 1"
+    assert_single_entry_trade(signals)
 
     # Check if the strategy maintains the buy position throughout
     assert (signals["signal"] == 1).all(), "Buy signal should be maintained throughout"
@@ -81,4 +85,4 @@ def test_buy_and_hold_strategy_with_various_price_movements():
 
     # Check if the strategy maintains the buy position regardless of price movements
     assert (signals["signal"] == 1).all(), "Buy signal should be maintained throughout"
-    assert (signals["position_change"] == 1).all(), "All position_change should be 1"
+    assert_single_entry_trade(signals)

--- a/tests/strategies/test_mean_reversion.py
+++ b/tests/strategies/test_mean_reversion.py
@@ -2,6 +2,8 @@
 Tests for the Mean Reversion strategy class.
 """
 
+from datetime import date, timedelta
+
 import polars as pl
 from quant_trading_strategy_backtester.strategies.mean_reversion import (
     MeanReversionStrategy,
@@ -33,3 +35,16 @@ def test_mean_reversion_strategy_generate_signals(
     for col in EXPECTED_COLS:
         assert col in signals.columns
     assert signals["signal"].is_in([0.0, 1.0, -1.0]).all()
+
+
+def test_mean_reversion_stays_flat_when_volatility_is_zero() -> None:
+    start_date = date(2023, 1, 1)
+    dates = [start_date + timedelta(days=i) for i in range(10)]
+    data = pl.DataFrame({"Date": dates, "Close": [100.0] * len(dates)})
+
+    strategy = MeanReversionStrategy({"window": 5, "std_dev": 2.0})
+    signals = strategy.generate_signals(data)
+
+    assert (signals["std"].drop_nulls() == 0.0).all()
+    assert (signals["signal"] == 0.0).all()
+    assert (signals["position_change"] == 0.0).all()

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -11,6 +11,7 @@ import pytest
 from quant_trading_strategy_backtester.backtester import Backtester
 from quant_trading_strategy_backtester.models import StrategyModel
 from quant_trading_strategy_backtester.strategies.base import BaseStrategy
+from quant_trading_strategy_backtester.strategies.buy_and_hold import BuyAndHoldStrategy
 from quant_trading_strategy_backtester.strategies.mean_reversion import (
     MeanReversionStrategy,
 )
@@ -376,3 +377,48 @@ def test_default_transaction_costs_reduce_returns():
     assert default_cum < zero_cum, (
         "Default costs should produce lower returns than zero costs"
     )
+
+
+def test_buy_and_hold_charges_initial_entry_cost_only():
+    """
+    Verify that buy and hold pays costs on entry rather than on every row.
+    """
+    data = pl.DataFrame(
+        {
+            "Date": [
+                datetime.date(2020, 1, 1),
+                datetime.date(2020, 1, 2),
+                datetime.date(2020, 1, 3),
+            ],
+            "Close": [100.0, 110.0, 121.0],
+        }
+    )
+    strategy = BuyAndHoldStrategy({})
+
+    bt_no_costs = Backtester(
+        data,
+        strategy,
+        transaction_cost_bps=0.0,
+        slippage_bps=0.0,
+    )
+    results_no_costs = bt_no_costs.run()
+
+    bt_with_costs = Backtester(
+        data,
+        strategy,
+        transaction_cost_bps=5.0,
+        slippage_bps=3.0,
+    )
+    results_with_costs = bt_with_costs.run()
+
+    cost_per_trade = 8.0 / 10_000
+    return_diffs = [
+        no_cost - with_cost
+        for no_cost, with_cost in zip(
+            results_no_costs["strategy_returns"],
+            results_with_costs["strategy_returns"],
+        )
+    ]
+
+    assert return_diffs == [cost_per_trade, 0.0, 0.0]
+    assert results_with_costs["position_change"].to_list() == [1.0, 0.0, 0.0]


### PR DESCRIPTION
# Summary
- Corrected buy-and-hold trade accounting so the benchmark paid entry costs once while holding a constant long position
- Guarded mean-reversion signal generation against invalid volatility windows
  - Flat or non-finite rolling bands now stayed neutral instead of creating false entries
- Added regression coverage around cost charging and zero-volatility mean-reversion behaviour

## Rationale
- `position_change` is the backtester's cost trigger
  - Treating a held position as a repeated daily change made buy-and-hold understate returns by charging costs every row
- Zero volatility should mean no actionable statistical band
  - The previous `NaN` band handling allowed flat price series to create false entries