### PR TITLE
fix: Avoid repeated pairs strategy optimisation

### DIFF
--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -240,39 +240,43 @@ def prepare_pairs_trading_strategy_with_optimisation(
     with st.spinner("Fetching top S&P 500 companies..."):
         top_companies = get_top_sp500_companies(NUM_TOP_COMPANIES_TWO_TICKERS)
 
-    # Optimise ticker pair selection and strategy parameters
-    ticker, strategy_params, _ = optimise_pairs_trading_tickers(
+    parameter_ranges = strategy_params
+
+    # Optimise ticker pair selection and strategy parameters.
+    ticker, selected_strategy_params, _ = optimise_pairs_trading_tickers(
         top_companies, start_date, end_date, strategy_params, optimise
     )
     ticker1, ticker2 = ticker
 
-    # Calculate and display the time taken for optimisation
+    # Load historical data for the selected pair.
+    data = load_yfinance_data_two_tickers(ticker1, ticker2, start_date, end_date)
+    ticker_display = f"{ticker1} vs. {ticker2}"
+
+    if optimise and walk_forward:
+        strategy_params, _ = run_optimisation(
+            data,
+            "Pairs Trading",
+            parameter_ranges,
+            start_date,
+            end_date,
+            [ticker1, ticker2],
+            walk_forward=walk_forward,
+        )
+    else:
+        strategy_params = selected_strategy_params
+
+    # Calculate and display the time taken for optimisation.
     end_time = time.time()
     duration = end_time - start_time
     st.success(f"Optimisation complete! Time taken: {duration:.4f} seconds")
 
-    # Display the optimal tickers and parameters
+    # Display the optimal tickers and parameters.
     st.header("Optimal Tickers and Parameters")
     tickers_and_strategy_params = {
         "ticker1": ticker1,
         "ticker2": ticker2,
     } | strategy_params
     st.write(tickers_and_strategy_params)
-
-    # Load historical data for the selected pair
-    data = load_yfinance_data_two_tickers(ticker1, ticker2, start_date, end_date)
-    ticker_display = f"{ticker1} vs. {ticker2}"
-
-    if optimise:
-        strategy_params, _ = run_optimisation(
-            data,
-            "Pairs Trading",
-            strategy_params,
-            start_date,
-            end_date,
-            [ticker1, ticker2],
-            walk_forward=walk_forward,
-        )
 
     return data, ticker_display, strategy_params
 

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -241,10 +241,7 @@ def test_handle_pairs_trading_optimisation(monkeypatch):
         return mock_polars_data
 
     def mock_run_optimisation(*args, **kwargs):
-        return (
-            {"window": 20, "entry_z_score": 2.0, "exit_z_score": 0.5},
-            {"Sharpe Ratio": 1.5, "Total Return": 0.2, "Max Drawdown": -0.1},
-        )
+        raise AssertionError("Pair optimisation should not run a second grid search")
 
     monkeypatch.setattr(
         "quant_trading_strategy_backtester.app.get_top_sp500_companies",
@@ -284,6 +281,80 @@ def test_handle_pairs_trading_optimisation(monkeypatch):
     assert optimised_params["window"] == 20
     assert optimised_params["entry_z_score"] == 2.0
     assert optimised_params["exit_z_score"] == 0.5
+
+
+def test_handle_pairs_trading_walk_forward_uses_original_ranges(monkeypatch):
+    mock_polars_data = pl.DataFrame(
+        {"Close_1": [100, 101, 102], "Close_2": [200, 202, 204]}
+    )
+    mock_top_companies = [("AAPL", 1000000), ("GOOGL", 900000), ("MSFT", 800000)]
+
+    def mock_get_top_companies(*args, **kwargs):
+        return mock_top_companies
+
+    def mock_optimise_pairs(*args, **kwargs):
+        return (
+            ("AAPL", "GOOGL"),
+            {"window": 20, "entry_z_score": 2.0, "exit_z_score": 0.5},
+            {"Sharpe Ratio": 1.5, "Total Return": 0.2, "Max Drawdown": -0.1},
+        )
+
+    def mock_load_data(*args, **kwargs):
+        return mock_polars_data
+
+    def mock_run_optimisation(
+        data,
+        strategy_type,
+        received_params,
+        start_date,
+        end_date,
+        tickers,
+        walk_forward=False,
+    ):
+        assert received_params == strategy_params
+        assert walk_forward is True
+        return (
+            {"window": 25, "entry_z_score": 2.5, "exit_z_score": 0.7},
+            {"Sharpe Ratio": 1.8, "Total Return": 0.3, "Max Drawdown": -0.1},
+        )
+
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.app.get_top_sp500_companies",
+        mock_get_top_companies,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.app.optimise_pairs_trading_tickers",
+        mock_optimise_pairs,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.app.load_yfinance_data_two_tickers",
+        mock_load_data,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.app.run_optimisation",
+        mock_run_optimisation,
+    )
+
+    start_date = datetime.date(2020, 1, 1)
+    end_date = datetime.date(2020, 12, 31)
+    strategy_params = {
+        "window": range(10, 31),
+        "entry_z_score": [1.5, 2.0, 2.5],
+        "exit_z_score": [0.3, 0.5, 0.7],
+    }
+
+    _, ticker_display, optimised_params = (
+        prepare_pairs_trading_strategy_with_optimisation(
+            start_date, end_date, strategy_params, True, walk_forward=True
+        )
+    )
+
+    assert ticker_display == "AAPL vs. GOOGL"
+    assert optimised_params == {
+        "window": 25,
+        "entry_z_score": 2.5,
+        "exit_z_score": 0.7,
+    }
 
 
 def test_run_optimisation(monkeypatch):


### PR DESCRIPTION
# Summary
- Preserved the original pairs-trading optimisation ranges separately from the selected scalar parameters
- Stopped the auto-selected pair flow from running a duplicate grid search after ticker-pair selection
- Added regression coverage for the standard and walk-forward auto-selection paths

## Rationale
- Pair selection and parameter selection produce different parameter shapes
  - The selected pair path returns scalar parameters, while walk-forward validation still needs the original iterable ranges
- Running a second optimisation after pair selection was both redundant and crash-prone
  - Non-walk-forward optimisation had already selected the best pair and parameters, so sending scalar values back into grid search could fail before the final backtest ran