### PR TITLE
fix: Use adjusted price data from Yahoo Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ _Try the deployed app
   pairs spread z-score charts with entry/exit threshold bands
 - **Performance metrics** – Total Return, Sharpe Ratio, Max Drawdown, and
   monthly performance table with rolling returns
-- **Real-time data fetching** – historical market data from Yahoo Finance
+- **Real-time data fetching** – adjusted historical market data from Yahoo
+  Finance
 
 ## Screenshots
 

--- a/src/quant_trading_strategy_backtester/data.py
+++ b/src/quant_trading_strategy_backtester/data.py
@@ -21,7 +21,7 @@ def load_yfinance_data_one_ticker(
     ticker: str, start_date: datetime.date, end_date: datetime.date
 ) -> pl.DataFrame:
     """
-    Fetches historical stock data for a ticker from Yahoo Finance.
+    Fetches adjusted historical stock data for a ticker from Yahoo Finance.
 
     Args:
         ticker: The stock ticker symbol.
@@ -29,9 +29,9 @@ def load_yfinance_data_one_ticker(
         end_date: The end date for the data.
 
     Returns:
-        A Polars DataFrame containing the historical stock data.
+        A Polars DataFrame containing adjusted historical stock data.
     """
-    data = yf.download(ticker, start=start_date, end=end_date, auto_adjust=False)
+    data = yf.download(ticker, start=start_date, end=end_date, auto_adjust=True)
     data = cast(pd.DataFrame, data)
     # Handle MultiIndex columns by taking just the first level
     if isinstance(data.columns, pd.MultiIndex):
@@ -47,7 +47,7 @@ def load_yfinance_data_two_tickers(
     ticker1: str, ticker2: str, start_date: datetime.date, end_date: datetime.date
 ) -> pl.DataFrame:
     """
-    Fetches historical stock data for two tickers from Yahoo Finance.
+    Fetches adjusted historical stock data for two tickers from Yahoo Finance.
 
     Args:
         ticker1: The first stock ticker symbol.
@@ -56,15 +56,15 @@ def load_yfinance_data_two_tickers(
         end_date: The end date for the data.
 
     Returns:
-        A Polars DataFrame containing the historical stock data for both tickers.
+        A Polars DataFrame containing adjusted historical stock data for both tickers.
     """
     # Download both tickers in one call for better performance.
     data = yf.download(
-        [ticker1, ticker2], start=start_date, end=end_date, auto_adjust=False
+        [ticker1, ticker2], start=start_date, end=end_date, auto_adjust=True
     )
     data = cast(pd.DataFrame, data)
 
-    # Extract Close prices for both tickers.
+    # Extract adjusted Close prices for both tickers.
     # When downloading multiple tickers, yfinance returns MultiIndex columns.
     if isinstance(data.columns, pd.MultiIndex):
         # Get Close prices for each ticker.

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -18,9 +18,13 @@ def test_load_yfinance_data_one_ticker(
     monkeypatch, mock_yfinance_data: pd.DataFrame
 ) -> None:
     def mock_download(*args, **kwargs):
-        return mock_yfinance_data.set_index("Date")
+        assert kwargs["auto_adjust"] is True
+        data = mock_yfinance_data.copy()
+        data["Close"] = data["Adj Close"]
+        return data.drop(columns=["Adj Close"]).set_index("Date")
 
     monkeypatch.setattr("yfinance.download", mock_download)
+    load_yfinance_data_one_ticker.clear()
 
     data = load_yfinance_data_one_ticker(
         "AAPL", datetime.date(2020, 1, 1), datetime.date(2020, 1, 31)
@@ -29,6 +33,7 @@ def test_load_yfinance_data_one_ticker(
     assert not data.is_empty()
     assert "Date" in data.columns
     assert "Close" in data.columns
+    assert "Adj Close" not in data.columns
     assert len(data) == 31
 
 
@@ -36,6 +41,7 @@ def test_load_yfinance_data_two_tickers(
     monkeypatch, mock_yfinance_data: pd.DataFrame
 ) -> None:
     def mock_download(*args, **kwargs):
+        assert kwargs["auto_adjust"] is True
         # yfinance returns MultiIndex columns when downloading multiple
         # tickers.
         base_data = mock_yfinance_data.set_index("Date")
@@ -55,6 +61,7 @@ def test_load_yfinance_data_two_tickers(
         return multi_index_data
 
     monkeypatch.setattr("yfinance.download", mock_download)
+    load_yfinance_data_two_tickers.clear()
 
     data = load_yfinance_data_two_tickers(
         "AAPL", "MSFT", datetime.date(2020, 1, 1), datetime.date(2020, 1, 31)


### PR DESCRIPTION
# Summary

- Switched yfinance downloads to use `auto_adjust=True` so that the `Close` column contains adjusted prices by default – previously used `auto_adjust=False` which returned unadjusted closes and a separate `Adj Close` column that was never consumed by the backtester
- Updated data-fetching docstrings and README to reflect that the returned data is now adjusted
- Fixed tests to assert the `auto_adjust` flag is `True`, simulate the adjusted price behaviour, and verify `Adj Close` is not present in output
- Added `clear()` calls on cached data-fetching functions in tests to avoid stale results between runs

## Rationale

- With `auto_adjust=False`, the backtester was operating on unadjusted close prices while ignoring the `Adj Close` column entirely – splits and dividends were silently distorting returns and strategy signals
- Setting `auto_adjust=True` lets yfinance fold adjustments into `Close` directly, so downstream code needs no special handling and the backtester sees corrected prices
- Clearing the `@lru_cache` in tests ensures each test case starts from a clean state rather than potentially reusing a cached result from a prior test invocation