### PR TITLE
fix: Evaluate optimised strategies on held-out data

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ _Try the deployed app
 - **Real-time data fetching** – adjusted historical market data from Yahoo
   Finance
 
+## Methodology Notes
+
+- **Ticker/pair selection** uses a 70/30 train/test split – tickers are
+  selected on training data and evaluated on held-out test data to reduce
+  look-ahead bias
+- **Walk-forward validation** uses expanding training windows for more
+  robust out-of-sample evaluation – recommended over the default split
+- **Survivorship bias** remains a limitation – automatic ticker selection uses
+  today's S&P 500 constituents, so historical results can still be biased
+  towards companies that survived to the current index
+
 ## Screenshots
 
 ![Pairs Trading without Optimisation 1](./resources/screenshots/pairs_trading_no_optimisation_1.png)

--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -27,6 +27,7 @@ from quant_trading_strategy_backtester.data import (
 from quant_trading_strategy_backtester.models import Session, StrategyModel
 from quant_trading_strategy_backtester.optimiser import (
     create_strategy,
+    get_validation_data,
     optimise_buy_and_hold_ticker,
     optimise_pairs_trading_tickers,
     optimise_single_ticker_strategy_ticker,
@@ -62,6 +63,34 @@ def _cached_run_backtest(
     Streamlit reruns.
     """
     return run_backtest(data, strategy_type, strategy_params, tickers)
+
+
+def _get_final_backtest_data(
+    data: pl.DataFrame, use_validation_data: bool, walk_forward: bool
+) -> pl.DataFrame:
+    """
+    Return the data used for the displayed and saved final backtest.
+
+    Args:
+        data: Full historical price data.
+        use_validation_data: Whether ticker selection or parameter optimisation
+            has already used the training period.
+        walk_forward: Whether parameter optimisation used walk-forward
+            validation.
+
+    Returns:
+        Full data for plain backtests, or held-out validation data for
+        optimised backtests.
+    """
+    if not use_validation_data:
+        return data
+
+    validation_data = get_validation_data(data, walk_forward=walk_forward)
+    if walk_forward:
+        st.info("Displaying final walk-forward test-fold backtest results.")
+    else:
+        st.info("Displaying held-out test-period backtest results.")
+    return validation_data
 
 
 # Trading strategy preparation functions
@@ -166,6 +195,13 @@ def prepare_single_ticker_strategy_with_optimisation(
 
     # Optimise strategy parameters if requested.
     if optimise:
+        if not walk_forward:
+            st.warning(
+                "Parameter optimisation without walk-forward validation "
+                "uses a single 70/30 train/test split. Results may still "
+                "be partially in-sample. Enable walk-forward validation "
+                "for more robust out-of-sample evaluation."
+            )
         best_params, _ = run_optimisation(
             data,
             strategy_type,
@@ -262,6 +298,14 @@ def prepare_pairs_trading_strategy_with_optimisation(
             [ticker1, ticker2],
             walk_forward=walk_forward,
         )
+    elif optimise and not walk_forward:
+        st.warning(
+            "Parameter optimisation without walk-forward validation "
+            "uses a single 70/30 train/test split. Results may still "
+            "be partially in-sample. Enable walk-forward validation "
+            "for more robust out-of-sample evaluation."
+        )
+        strategy_params = selected_strategy_params
     else:
         strategy_params = selected_strategy_params
 
@@ -515,7 +559,11 @@ def main():
     if strategy_type == "Pairs Trading" and auto_select_tickers:
         data, ticker_display, strategy_params = (
             prepare_pairs_trading_strategy_with_optimisation(
-                start_date, end_date, strategy_params, optimise, walk_forward
+                start_date,
+                end_date,
+                strategy_params,
+                optimise,
+                walk_forward,
             )
         )
         # Update company names with the selected pair
@@ -580,8 +628,16 @@ def main():
         if strategy_type == "Pairs Trading"
         else ticker_display
     )
+    use_validation_data = auto_select_tickers or optimise
+    backtest_data = _get_final_backtest_data(
+        data, use_validation_data, walk_forward=walk_forward
+    )
+    if backtest_data.is_empty():
+        st.write("No validation data available for the selected ticker and date range")
+        return
+
     results, metrics = _cached_run_backtest(
-        data, strategy_type, strategy_params, tickers
+        backtest_data, strategy_type, strategy_params, tickers
     )
 
     # Save only the final backtest result, and only once per unique
@@ -589,7 +645,7 @@ def main():
     _save_key = f"{strategy_type}:{strategy_params}:{tickers}"
     if st.session_state.get("_last_saved_key") != _save_key:
         strategy = create_strategy(strategy_type, strategy_params)
-        backtester = Backtester(data, strategy, tickers=tickers)
+        backtester = Backtester(backtest_data, strategy, tickers=tickers)
         backtester.results = results
         backtester.save_results()
         st.session_state["_last_saved_key"] = _save_key
@@ -615,7 +671,7 @@ def main():
     # Display the raw data from Yahoo Finance for the backtest period
     st.header(f"Raw Data for {company_display}")
     st.dataframe(
-        data.to_pandas(),
+        backtest_data.to_pandas(),
         width="stretch",
         hide_index=True,
     )

--- a/src/quant_trading_strategy_backtester/data.py
+++ b/src/quant_trading_strategy_backtester/data.py
@@ -104,8 +104,7 @@ def get_ticker_market_cap(ticker: str) -> tuple[str, float | None]:
 @st.cache_data
 def get_top_sp500_companies(num_companies: int) -> list[tuple[str, float]]:
     """
-    Fetches the top X companies in the S&P 500 index by market cap using
-    yfinance.
+    Fetches the top X companies in the S&P 500 index by market cap.
 
     Args:
         num_companies: The number of top companies to fetch.

--- a/src/quant_trading_strategy_backtester/optimiser.py
+++ b/src/quant_trading_strategy_backtester/optimiser.py
@@ -34,6 +34,54 @@ from quant_trading_strategy_backtester.strategies.pairs_trading import (
 )
 from quant_trading_strategy_backtester.utils import NUM_TOP_COMPANIES_ONE_TICKER
 
+TRAIN_RATIO = 0.7
+WALK_FORWARD_FOLDS = 5
+
+
+def _split_data(
+    data: pl.DataFrame, train_ratio: float = TRAIN_RATIO
+) -> tuple[pl.DataFrame, pl.DataFrame]:
+    """
+    Split a DataFrame into training and test sets by row count.
+
+    Args:
+        data: The full dataset to split.
+        train_ratio: Fraction of rows to use for training (default 0.7).
+
+    Returns:
+        A tuple of (train_data, test_data).
+    """
+    split_idx = int(len(data) * train_ratio)
+    return data[:split_idx], data[split_idx:]
+
+
+def get_validation_data(
+    data: pl.DataFrame, walk_forward: bool = False, n_folds: int = WALK_FORWARD_FOLDS
+) -> pl.DataFrame:
+    """
+    Return the held-out data used for final validation display.
+
+    Args:
+        data: Historical price data.
+        walk_forward: Whether the optimisation used walk-forward validation.
+        n_folds: Number of walk-forward test folds.
+
+    Returns:
+        The test split for standard optimisation, or the final test fold for
+        walk-forward optimisation.
+    """
+    if walk_forward:
+        segment_size = len(data) // (n_folds + 1)
+        if segment_size < 2:
+            raise ValueError(
+                f"Not enough data for {n_folds} folds: "
+                f"{len(data)} rows, need at least {2 * (n_folds + 1)}"
+            )
+        return data[segment_size * n_folds : segment_size * (n_folds + 1)]
+
+    _, test_data = _split_data(data)
+    return test_data
+
 
 def run_optimisation(
     data: pl.DataFrame,
@@ -79,11 +127,13 @@ def run_optimisation(
         )
         _display_walk_forward_results(fold_results)
     else:
+        train_data, test_data = _split_data(data)
         strategy_params, metrics = optimise_strategy_params(
-            data,
+            train_data,
             strategy_type,
             cast(dict[str, range | list[int | float]], strategy_params),
             tickers,
+            test_data=test_data,
         )
 
     end_time = time.time()
@@ -131,6 +181,9 @@ def optimise_buy_and_hold_ticker(
     """
     Optimises ticker selection for the Buy and Hold strategy.
 
+    Uses a 70/30 train/test split: tickers are ranked by total return on
+    training data, and the winner is re-evaluated on test data.
+
     Args:
         top_companies: List of tuples containing ticker symbols and market caps
                        of top companies.
@@ -139,10 +192,10 @@ def optimise_buy_and_hold_ticker(
 
     Returns:
         A tuple containing the best ticker, strategy parameters, and
-        performance metrics.
+        out-of-sample performance metrics.
     """
     best_ticker = None
-    best_metrics = None
+    best_test_data = None
     best_total_return = float("-inf")
 
     total_tickers = len(top_companies)
@@ -157,23 +210,30 @@ def optimise_buy_and_hold_ticker(
         if data is None or data.is_empty():
             continue
 
-        strategy = BuyAndHoldStrategy({})
-        backtester = Backtester(data, strategy, tickers=ticker)
-        backtester.run()
-        metrics = backtester.get_performance_metrics()
+        train_data, test_data = _split_data(data)
 
-        if metrics and metrics["Total Return"] > best_total_return:
-            best_total_return = metrics["Total Return"]
+        backtester = Backtester(train_data, BuyAndHoldStrategy({}), tickers=ticker)
+        backtester.run()
+        train_metrics = backtester.get_performance_metrics()
+
+        if train_metrics and train_metrics["Total Return"] > best_total_return:
+            best_total_return = train_metrics["Total Return"]
             best_ticker = ticker
-            best_metrics = metrics
+            best_test_data = test_data
 
     progress_bar.empty()
     status_text.empty()
 
-    if not best_ticker or not best_metrics:
+    if not best_ticker or best_test_data is None:
         raise ValueError("Buy and Hold optimisation failed")
 
-    return best_ticker, {}, best_metrics
+    backtester = Backtester(best_test_data, BuyAndHoldStrategy({}), tickers=best_ticker)
+    backtester.run()
+    best_test_metrics = backtester.get_performance_metrics()
+    if best_test_metrics is None:
+        raise ValueError("Buy and Hold optimisation failed")
+
+    return best_ticker, {}, best_test_metrics
 
 
 def optimise_single_ticker_strategy_ticker(
@@ -185,6 +245,9 @@ def optimise_single_ticker_strategy_ticker(
 ) -> str:
     """
     Optimises ticker selection for single ticker strategies.
+
+    Uses a 70/30 train/test split: tickers are ranked by Sharpe ratio on
+    training data.
 
     Args:
         top_companies: List of tuples containing ticker symbols and market caps
@@ -218,10 +281,11 @@ def optimise_single_ticker_strategy_ticker(
         if data is None or data.is_empty():
             continue
 
-        _, current_metrics = run_backtest(data, strategy_type, fixed_params, ticker)
+        train_data, _ = _split_data(data)
+        _, train_metrics = run_backtest(train_data, strategy_type, fixed_params, ticker)
 
-        if current_metrics["Sharpe Ratio"] > best_sharpe_ratio:
-            best_sharpe_ratio = current_metrics["Sharpe Ratio"]
+        if train_metrics["Sharpe Ratio"] > best_sharpe_ratio:
+            best_sharpe_ratio = train_metrics["Sharpe Ratio"]
             best_ticker = ticker
 
     progress_bar.empty()
@@ -238,17 +302,23 @@ def optimise_strategy_params(
     strategy_type: str,
     parameter_ranges: dict[str, range | list[int | float]],
     tickers: str | list[str],
+    test_data: pl.DataFrame | None = None,
 ) -> tuple[dict[str, int | float], dict[str, float]]:
     """
     Optimises strategy parameters by testing all combinations within given
     ranges.
 
+    Grid search runs on `data` (training set). If `test_data` is provided,
+    the best parameters are evaluated on it and out-of-sample metrics are
+    returned. Otherwise, in-sample metrics are returned.
+
     Args:
-        data: Historical price data.
+        data: Training price data for grid search.
         strategy_type: The type of strategy to optimise.
         parameter_ranges: A dictionary of parameters and their possible values
                           to test.
         tickers: The ticker or tickers used in the backtest.
+        test_data: Optional held-out test data for out-of-sample evaluation.
 
     Returns:
         A tuple containing the best parameters and their performance metrics.
@@ -288,6 +358,11 @@ def optimise_strategy_params(
     if not best_params or not best_metrics:
         raise ValueError("Parameter optimisation failed")
 
+    # Evaluate best params on held-out test data if provided.
+    if test_data is not None:
+        _, test_metrics = run_backtest(test_data, strategy_type, best_params, tickers)
+        return best_params, test_metrics
+
     return best_params, best_metrics
 
 
@@ -300,6 +375,10 @@ def optimise_pairs_trading_tickers(
 ) -> tuple[tuple[str, str], dict[str, Any], dict[str, float]]:
     """
     Optimises ticker pair selection and strategy parameters for pairs trading.
+
+    Uses a 70/30 train/test split: pairs are ranked by Sharpe ratio on
+    training data. When `optimise` is True, parameter fitting also runs
+    on training data and the winner is evaluated on test data.
 
     Args:
         top_companies: List of tuples containing ticker symbols and market caps
@@ -315,7 +394,7 @@ def optimise_pairs_trading_tickers(
     """
     best_pair = None
     best_params = None
-    best_metrics = None
+    best_test_data = None
     best_sharpe_ratio = float("-inf")
 
     ticker_pairs = list(
@@ -343,34 +422,43 @@ def optimise_pairs_trading_tickers(
         if data is None or data.is_empty():
             continue
 
+        train_data, test_data = _split_data(data)
+
         if optimise:
             # Convert single values to lists for optimisation
             param_ranges = {
                 k: [v] if isinstance(v, (int, float)) else v
                 for k, v in strategy_params.items()
             }
-            current_params, current_metrics = optimise_strategy_params(
-                data, "Pairs Trading", param_ranges, [ticker1, ticker2]
+            current_params, train_metrics = optimise_strategy_params(
+                train_data,
+                "Pairs Trading",
+                param_ranges,
+                [ticker1, ticker2],
             )
         else:
-            _, current_metrics = run_backtest(
-                data, "Pairs Trading", strategy_params, [ticker1, ticker2]
+            _, train_metrics = run_backtest(
+                train_data, "Pairs Trading", strategy_params, [ticker1, ticker2]
             )
             current_params = strategy_params
 
-        if current_metrics["Sharpe Ratio"] > best_sharpe_ratio:
-            best_sharpe_ratio = current_metrics["Sharpe Ratio"]
+        if train_metrics["Sharpe Ratio"] > best_sharpe_ratio:
+            best_sharpe_ratio = train_metrics["Sharpe Ratio"]
             best_pair = (ticker1, ticker2)
             best_params = current_params
-            best_metrics = current_metrics
+            best_test_data = test_data
 
         end_time = time.time()
         prev_pair_processing_time = end_time - start_time
 
     progress_bar.empty()
     status_text.empty()
-    if not best_pair or not best_params or not best_metrics:
+    if not best_pair or not best_params or best_test_data is None:
         raise ValueError("Pairs trading optimisation failed")
+
+    _, best_metrics = run_backtest(
+        best_test_data, "Pairs Trading", best_params, list(best_pair)
+    )
 
     return best_pair, best_params, best_metrics
 
@@ -380,7 +468,7 @@ def walk_forward_optimise(
     strategy_type: str,
     parameter_ranges: dict[str, range | list[int | float]],
     tickers: str | list[str],
-    n_folds: int = 5,
+    n_folds: int = WALK_FORWARD_FOLDS,
 ) -> tuple[dict[str, int | float], dict[str, float], list[dict]]:
     """
     Optimises strategy parameters using walk-forward validation.

--- a/src/quant_trading_strategy_backtester/streamlit_ui.py
+++ b/src/quant_trading_strategy_backtester/streamlit_ui.py
@@ -22,7 +22,7 @@ def get_user_inputs_except_strategy_params() -> tuple[
 
     Returns:
         A tuple containing the ticker symbol(s), start date, end date, strategy
-        type, and a boolean indicating whether to use automatic ticker
+        type, a boolean indicating whether to use automatic ticker
         selection for pairs trading or buy and hold.
     """
     strategy_type = st.sidebar.selectbox("Strategy Type", TRADING_STRATEGIES, index=0)
@@ -63,7 +63,13 @@ def get_user_inputs_except_strategy_params() -> tuple[
     start_date = st.sidebar.date_input("Start Date", value=datetime.date(2020, 1, 1))
     end_date = st.sidebar.date_input("End Date", value=datetime.date(2023, 12, 31))
 
-    return ticker, start_date, end_date, strategy_type, auto_select_tickers
+    return (
+        ticker,
+        start_date,
+        end_date,
+        strategy_type,
+        auto_select_tickers,
+    )
 
 
 def get_optimisation_ranges(strategy_type: str) -> dict[str, Any]:
@@ -179,7 +185,8 @@ def get_user_inputs_for_strategy_params(
             help=(
                 "Split data into multiple folds and optimise on "
                 "each training window, then evaluate out-of-sample."
-                " Shows parameter stability over time."
+                " Shows parameter stability over time. Without this,"
+                " optimisation uses a single 70/30 train/test split."
             ),
         )
     else:

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -8,14 +8,18 @@ from typing import Any
 import polars as pl
 import pytest
 from quant_trading_strategy_backtester.app import (
+    _get_final_backtest_data,
     prepare_buy_and_hold_strategy_with_optimisation,
     prepare_pairs_trading_strategy_with_optimisation,
     prepare_single_ticker_strategy_with_optimisation,
 )
 from quant_trading_strategy_backtester.optimiser import (
+    _split_data,
+    get_validation_data,
     optimise_buy_and_hold_ticker,
     optimise_pairs_trading_tickers,
     optimise_single_ticker_strategy_ticker,
+    optimise_strategy_params,
     run_backtest,
     run_optimisation,
     walk_forward_optimise,
@@ -181,6 +185,14 @@ def test_optimise_pairs_trading_tickers(monkeypatch):
         mock_load_data,
     )
     monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.load_yfinance_data_two_tickers",
+        mock_load_data,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.is_same_company",
+        lambda *_args: False,
+    )
+    monkeypatch.setattr(
         "quant_trading_strategy_backtester.optimiser.run_backtest", mock_run_backtest
     )
     monkeypatch.setattr(
@@ -218,6 +230,150 @@ def test_optimise_pairs_trading_tickers(monkeypatch):
     assert isinstance(best_params, dict)
     # Should be the same as input when not optimising
     assert best_params == strategy_params
+
+
+def test_optimise_pairs_trading_tickers_ranks_fixed_pairs_on_train(monkeypatch):
+    """Verify fixed-parameter pair selection ignores held-out test metrics."""
+    mock_top_companies = [("AAPL", 1000000.0), ("GOOGL", 900000.0), ("MSFT", 800000.0)]
+    dates = [datetime.date(2020, 1, 1) + datetime.timedelta(days=i) for i in range(10)]
+    mock_polars_data = pl.DataFrame(
+        {
+            "Date": dates,
+            "Close_1": [100.0 + i for i in range(10)],
+            "Close_2": [200.0 + i for i in range(10)],
+        }
+    )
+    strategy_params = {"window": 20, "entry_z_score": 2.0, "exit_z_score": 0.5}
+    train_scores = {
+        ("AAPL", "GOOGL"): 1.0,
+        ("AAPL", "MSFT"): 2.0,
+        ("GOOGL", "MSFT"): 0.5,
+    }
+    test_scores = {
+        ("AAPL", "GOOGL"): 99.0,
+        ("AAPL", "MSFT"): -1.0,
+        ("GOOGL", "MSFT"): 0.0,
+    }
+
+    def mock_load_data(*args, **kwargs):
+        return mock_polars_data
+
+    def mock_run_backtest(data, strategy_type, params, tickers):
+        pair = tuple(tickers)
+        scores = train_scores if len(data) == 7 else test_scores
+        return None, {
+            "Sharpe Ratio": scores[pair],
+            "Total Return": 0.1,
+            "Max Drawdown": -0.05,
+        }
+
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.load_yfinance_data_two_tickers",
+        mock_load_data,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.is_same_company",
+        lambda *_args: False,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.run_backtest", mock_run_backtest
+    )
+
+    best_pair, best_params, metrics = optimise_pairs_trading_tickers(
+        mock_top_companies,
+        datetime.date(2020, 1, 1),
+        datetime.date(2020, 12, 31),
+        strategy_params,
+        optimise=False,
+    )
+
+    assert best_pair == ("AAPL", "MSFT")
+    assert best_params == strategy_params
+    assert metrics["Sharpe Ratio"] == -1.0
+
+
+def test_optimise_pairs_trading_tickers_ranks_optimised_pairs_on_train(
+    monkeypatch,
+):
+    """Verify optimised pair selection does not pass test data into grid search."""
+    mock_top_companies = [("AAPL", 1000000.0), ("GOOGL", 900000.0), ("MSFT", 800000.0)]
+    dates = [datetime.date(2020, 1, 1) + datetime.timedelta(days=i) for i in range(10)]
+    mock_polars_data = pl.DataFrame(
+        {
+            "Date": dates,
+            "Close_1": [100.0 + i for i in range(10)],
+            "Close_2": [200.0 + i for i in range(10)],
+        }
+    )
+    strategy_params = {"window": [20, 30], "entry_z_score": [2.0], "exit_z_score": [0.5]}
+    train_scores = {
+        ("AAPL", "GOOGL"): 1.0,
+        ("AAPL", "MSFT"): 2.0,
+        ("GOOGL", "MSFT"): 0.5,
+    }
+
+    def mock_load_data(*args, **kwargs):
+        return mock_polars_data
+
+    def mock_optimise_strategy_params(
+        data,
+        strategy_type,
+        parameter_ranges,
+        tickers,
+        test_data=None,
+    ):
+        assert test_data is None
+        assert len(data) == 7
+        pair = tuple(tickers)
+        return {
+            "window": 20,
+            "entry_z_score": 2.0,
+            "exit_z_score": 0.5,
+        }, {
+            "Sharpe Ratio": train_scores[pair],
+            "Total Return": 0.1,
+            "Max Drawdown": -0.05,
+        }
+
+    def mock_run_backtest(data, strategy_type, params, tickers):
+        assert len(data) == 3
+        return None, {
+            "Sharpe Ratio": -1.0,
+            "Total Return": 0.01,
+            "Max Drawdown": -0.02,
+        }
+
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.load_yfinance_data_two_tickers",
+        mock_load_data,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.is_same_company",
+        lambda *_args: False,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.optimise_strategy_params",
+        mock_optimise_strategy_params,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.run_backtest", mock_run_backtest
+    )
+
+    best_pair, best_params, metrics = optimise_pairs_trading_tickers(
+        mock_top_companies,
+        datetime.date(2020, 1, 1),
+        datetime.date(2020, 12, 31),
+        strategy_params,
+        optimise=True,
+    )
+
+    assert best_pair == ("AAPL", "MSFT")
+    assert best_params == {
+        "window": 20,
+        "entry_z_score": 2.0,
+        "exit_z_score": 0.5,
+    }
+    assert metrics["Sharpe Ratio"] == -1.0
 
 
 def test_handle_pairs_trading_optimisation(monkeypatch):
@@ -671,3 +827,187 @@ def test_walk_forward_optimise_insufficient_data():
             tickers="TEST",
             n_folds=5,
         )
+
+
+def test_split_data():
+    """Verify _split_data splits at the correct ratio."""
+    data = pl.DataFrame({"Close": list(range(100))})
+    train, test = _split_data(data, train_ratio=0.7)
+    assert len(train) == 70
+    assert len(test) == 30
+    assert train["Close"][0] == 0
+    assert train["Close"][-1] == 69
+    assert test["Close"][0] == 70
+    assert test["Close"][-1] == 99
+
+
+def test_split_data_small_dataset():
+    """Verify _split_data handles small datasets."""
+    data = pl.DataFrame({"Close": [1, 2, 3]})
+    train, test = _split_data(data, train_ratio=0.7)
+    assert len(train) == 2
+    assert len(test) == 1
+
+
+def test_get_validation_data_standard_split():
+    """Verify standard optimisation validation uses the 30% test split."""
+    data = pl.DataFrame({"Close": list(range(100))})
+    validation_data = get_validation_data(data)
+    assert len(validation_data) == 30
+    assert validation_data["Close"][0] == 70
+    assert validation_data["Close"][-1] == 99
+
+
+def test_get_validation_data_walk_forward():
+    """Verify walk-forward validation uses the final test fold."""
+    data = pl.DataFrame({"Close": list(range(60))})
+    validation_data = get_validation_data(data, walk_forward=True, n_folds=5)
+    assert len(validation_data) == 10
+    assert validation_data["Close"][0] == 50
+    assert validation_data["Close"][-1] == 59
+
+
+def test_get_final_backtest_data_uses_validation_split():
+    """Verify optimised app results use validation-period data."""
+    data = pl.DataFrame({"Close": list(range(100))})
+    validation_data = _get_final_backtest_data(
+        data, use_validation_data=True, walk_forward=False
+    )
+    full_data = _get_final_backtest_data(
+        data, use_validation_data=False, walk_forward=False
+    )
+
+    assert len(validation_data) == 30
+    assert validation_data["Close"][0] == 70
+    assert len(full_data) == 100
+
+
+def test_optimise_strategy_params_returns_test_metrics(monkeypatch):
+    """Verify optimise_strategy_params evaluates best params on test data."""
+    train_data = pl.DataFrame(
+        {
+            "Date": [datetime.date(2020, 1, i) for i in range(1, 22)],
+            "Close": [100 + i for i in range(21)],
+        }
+    )
+    test_data = pl.DataFrame(
+        {
+            "Date": [datetime.date(2020, 2, i) for i in range(1, 11)],
+            "Close": [120 + i for i in range(10)],
+        }
+    )
+
+    call_log = []
+
+    def mock_run_backtest(data, strategy_type, params, tickers):
+        call_log.append(("backtest", len(data)))
+        # Return different metrics for train vs test
+        if len(data) == 21:
+            return None, {
+                "Sharpe Ratio": 1.0,
+                "Total Return": 0.1,
+                "Max Drawdown": -0.05,
+            }
+        else:
+            return None, {
+                "Sharpe Ratio": 0.5,
+                "Total Return": 0.05,
+                "Max Drawdown": -0.03,
+            }
+
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.run_backtest", mock_run_backtest
+    )
+
+    params, metrics = optimise_strategy_params(
+        train_data,
+        "Moving Average Crossover",
+        {"short_window": [5], "long_window": [20]},
+        "AAPL",
+        test_data=test_data,
+    )
+
+    # Should have run backtests for each param combo on train + once on test
+    assert len(call_log) == 2  # 1 train combo + 1 test eval
+    assert call_log[0] == ("backtest", 21)  # train
+    assert call_log[1] == ("backtest", 10)  # test
+    # Metrics should be from test data
+    assert metrics["Sharpe Ratio"] == 0.5
+    assert metrics["Total Return"] == 0.05
+
+
+def test_optimise_buy_and_hold_ticker_uses_train_test_split(monkeypatch):
+    """Verify buy-and-hold ticker selection uses train for ranking, test for eval."""
+    mock_top_companies = [("AAPL", 1000000.0), ("GOOGL", 900000.0)]
+
+    dates = [datetime.date(2020, 1, 1) + datetime.timedelta(days=i) for i in range(100)]
+    mock_data = pl.DataFrame(
+        {
+            "Date": dates,
+            "Close": [100.0 + i for i in range(100)],
+        }
+    )
+
+    def mock_load_data(*args, **kwargs):
+        return mock_data
+
+    split_calls = []
+    original_split = _split_data
+
+    def tracking_split(data, train_ratio=0.7):
+        train, test = original_split(data, train_ratio)
+        split_calls.append((len(train), len(test)))
+        return train, test
+
+    backtest_calls = []
+
+    class MockBacktester:
+        def __init__(self, data, strategy, tickers):
+            self.tickers = tickers
+            backtest_calls.append(len(data))
+
+        def run(self):
+            return None
+
+        def get_performance_metrics(self):
+            returns = {"AAPL": 0.3, "GOOGL": 0.2}
+            return {
+                "Total Return": returns.get(self.tickers, 0.1),
+                "Sharpe Ratio": 1.5,
+                "Max Drawdown": -0.1,
+            }
+
+    def mock_backtest_init(data, strategy, tickers):
+        returns = {"AAPL": 0.3, "GOOGL": 0.2}
+        assert tickers in returns
+        return MockBacktester(data, strategy, tickers)
+
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.data.load_yfinance_data_one_ticker",
+        mock_load_data,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.load_yfinance_data_one_ticker",
+        mock_load_data,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser._split_data", tracking_split
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.Backtester", mock_backtest_init
+    )
+
+    best_ticker, params, metrics = optimise_buy_and_hold_ticker(
+        mock_top_companies, datetime.date(2020, 1, 1), datetime.date(2020, 12, 31)
+    )
+
+    assert best_ticker == "AAPL"
+    assert params == {}
+    assert metrics["Total Return"] == 0.3
+    assert backtest_calls == [70, 70, 30]
+    # Verify _split_data was called (train/test split happened)
+    assert len(split_calls) >= 1
+    train_size, test_size = split_calls[0]
+    assert train_size + test_size == 100
+    assert train_size == 70  # 70% of 100
+    assert test_size == 30  # 30% of 100

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -305,7 +305,11 @@ def test_optimise_pairs_trading_tickers_ranks_optimised_pairs_on_train(
             "Close_2": [200.0 + i for i in range(10)],
         }
     )
-    strategy_params = {"window": [20, 30], "entry_z_score": [2.0], "exit_z_score": [0.5]}
+    strategy_params = {
+        "window": [20, 30],
+        "entry_z_score": [2.0],
+        "exit_z_score": [0.5],
+    }
     train_scores = {
         ("AAPL", "GOOGL"): 1.0,
         ("AAPL", "MSFT"): 2.0,


### PR DESCRIPTION
# Summary
- Added held-out validation as the default final evaluation path for optimised strategies
  - Standard optimisation used a 70/30 split
  - Walk-forward optimisation displayed the final test fold rather than the full period
- Updated ticker and pair selection to rank candidates only on training metrics
  - The selected candidate was evaluated once on held-out data after selection
  - Pair grid search no longer received the test split while choosing the winning pair
- Kept automatic S&P 500 selection honest about survivorship bias
  - The README documented the current-constituent limitation instead of claiming a historical universe filter
- Added regressions around train/test splitting, final validation display, and pair-selection leakage

## Rationale
- Optimisation output was still misleading if the app displayed a full-period backtest afterwards
  - Using the same full dataset for display made the internal split invisible and reintroduced in-sample reporting at the UI layer
- Pair selection needed a stricter boundary than parameter optimisation
  - Evaluating every candidate pair on test data before choosing the winner turned the test set into a selection input
- The S&P 500 universe caveat is left explicit
  - A static unsourced constituent list would look more rigorous than it actually was, so this PR documented the remaining limitation instead