### PR TITLE
fix: Harden Yahoo pair loading and strategy parameter inputs

### DIFF
--- a/src/quant_trading_strategy_backtester/data.py
+++ b/src/quant_trading_strategy_backtester/data.py
@@ -58,20 +58,31 @@ def load_yfinance_data_two_tickers(
     Returns:
         A Polars DataFrame containing adjusted historical stock data for both tickers.
     """
+    ticker1 = ticker1.strip().upper()
+    ticker2 = ticker2.strip().upper()
+    if ticker1 == ticker2:
+        raise ValueError("Ticker symbols must be different")
+
     # Download both tickers in one call for better performance.
     data = yf.download(
         [ticker1, ticker2], start=start_date, end=end_date, auto_adjust=True
     )
     data = cast(pd.DataFrame, data)
+    if data.empty:
+        return _empty_two_ticker_data()
 
-    # Extract adjusted Close prices for both tickers.
-    # When downloading multiple tickers, yfinance returns MultiIndex columns.
-    if isinstance(data.columns, pd.MultiIndex):
-        # Get Close prices for each ticker.
-        close_data = data["Close"]
-        close_data = close_data.reset_index()
-        # Rename columns to match expected format.
-        close_data.columns = ["Date", "Close_1", "Close_2"]
+    if not isinstance(data.columns, pd.MultiIndex):
+        raise ValueError("Expected MultiIndex columns for two-ticker yfinance data")
+
+    close_1 = _select_close_series(data, ticker1)
+    close_2 = _select_close_series(data, ticker2)
+    close_data = pd.DataFrame(
+        {
+            "Date": data.index,
+            "Close_1": close_1.to_numpy(),
+            "Close_2": close_2.to_numpy(),
+        }
+    )
 
     # Convert to Polars.
     combined_data = pl.from_pandas(close_data)
@@ -79,6 +90,44 @@ def load_yfinance_data_two_tickers(
     combined_data = combined_data.drop_nulls()
 
     return combined_data
+
+
+def _select_close_series(data: pd.DataFrame, ticker: str) -> pd.Series:
+    """
+    Select a ticker's close series from either yfinance MultiIndex layout.
+
+    Args:
+        data: The yfinance response for multiple tickers.
+        ticker: The ticker whose close prices should be selected.
+
+    Returns:
+        The ticker's close-price series.
+
+    Raises:
+        ValueError: If the response does not contain exactly one close column.
+    """
+    matches = [
+        column
+        for column in data.columns
+        if isinstance(column, tuple) and "Close" in column and ticker in column
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"Expected exactly one Close column for {ticker}, found {len(matches)}"
+        )
+
+    return data[matches[0]]
+
+
+def _empty_two_ticker_data() -> pl.DataFrame:
+    """Return the empty schema expected by pairs-trading callers."""
+    return pl.DataFrame(
+        schema={
+            "Date": pl.Datetime,
+            "Close_1": pl.Float64,
+            "Close_2": pl.Float64,
+        }
+    )
 
 
 @st.cache_data

--- a/src/quant_trading_strategy_backtester/optimiser.py
+++ b/src/quant_trading_strategy_backtester/optimiser.py
@@ -330,9 +330,7 @@ def optimise_strategy_params(
     best_metrics = None
     best_sharpe_ratio = float("-inf")
 
-    param_combinations = _valid_parameter_combinations(
-        strategy_type, parameter_ranges
-    )
+    param_combinations = _valid_parameter_combinations(strategy_type, parameter_ranges)
     total_combinations = len(param_combinations)
     if total_combinations == 0:
         raise ValueError(f"No valid parameter combinations for {strategy_type}")
@@ -501,9 +499,7 @@ def walk_forward_optimise(
             f"{n_rows} rows, need at least {2 * (n_folds + 1)}"
         )
 
-    param_combinations = _valid_parameter_combinations(
-        strategy_type, parameter_ranges
-    )
+    param_combinations = _valid_parameter_combinations(strategy_type, parameter_ranges)
     if not param_combinations:
         raise ValueError(f"No valid parameter combinations for {strategy_type}")
 

--- a/src/quant_trading_strategy_backtester/optimiser.py
+++ b/src/quant_trading_strategy_backtester/optimiser.py
@@ -32,6 +32,9 @@ from quant_trading_strategy_backtester.strategies.moving_average_crossover impor
 from quant_trading_strategy_backtester.strategies.pairs_trading import (
     PairsTradingStrategy,
 )
+from quant_trading_strategy_backtester.strategy_params import (
+    is_valid_strategy_params,
+)
 from quant_trading_strategy_backtester.utils import NUM_TOP_COMPANIES_ONE_TICKER
 
 TRAIN_RATIO = 0.7
@@ -327,25 +330,23 @@ def optimise_strategy_params(
     best_metrics = None
     best_sharpe_ratio = float("-inf")
 
-    param_names = list(parameter_ranges.keys())
-    param_values = [
-        list(value) if isinstance(value, range) else value
-        for value in parameter_ranges.values()
-    ]
-
-    param_combinations = list(itertools.product(*param_values))
+    param_combinations = _valid_parameter_combinations(
+        strategy_type, parameter_ranges
+    )
     total_combinations = len(param_combinations)
+    if total_combinations == 0:
+        raise ValueError(f"No valid parameter combinations for {strategy_type}")
+
     # Display progress bar and status text, as this process may take a while.
     progress_bar = st.progress(0)
     status_text = st.empty()
 
-    for i, params in enumerate(param_combinations):
+    for i, current_params in enumerate(param_combinations):
         status_text.text(
             f"Evaluating parameter combination {i + 1} / {total_combinations}"
         )
         progress_bar.progress((i + 1) / total_combinations)
 
-        current_params = dict(zip(param_names, params))
         _, metrics = run_backtest(data, strategy_type, current_params, tickers)
 
         if metrics["Sharpe Ratio"] > best_sharpe_ratio:
@@ -500,11 +501,11 @@ def walk_forward_optimise(
             f"{n_rows} rows, need at least {2 * (n_folds + 1)}"
         )
 
-    param_names = list(parameter_ranges.keys())
-    param_values = [
-        list(v) if isinstance(v, range) else v for v in parameter_ranges.values()
-    ]
-    param_combinations = list(itertools.product(*param_values))
+    param_combinations = _valid_parameter_combinations(
+        strategy_type, parameter_ranges
+    )
+    if not param_combinations:
+        raise ValueError(f"No valid parameter combinations for {strategy_type}")
 
     fold_results: list[dict] = []
 
@@ -517,8 +518,7 @@ def walk_forward_optimise(
         # Grid search on training data.
         best_sharpe = float("-inf")
         best_params: dict[str, int | float] | None = None
-        for params in param_combinations:
-            current_params = dict(zip(param_names, params))
+        for current_params in param_combinations:
             _, metrics = run_backtest(
                 train_data, strategy_type, current_params, tickers
             )
@@ -554,6 +554,35 @@ def walk_forward_optimise(
     final_params = fold_results[-1]["params"]
 
     return final_params, aggregated_metrics, fold_results
+
+
+def _valid_parameter_combinations(
+    strategy_type: str,
+    parameter_ranges: dict[str, range | list[int | float]],
+) -> list[dict[str, int | float]]:
+    """
+    Return scalar parameter combinations that pass strategy validation.
+
+    Args:
+        strategy_type: The strategy being optimised.
+        parameter_ranges: Candidate values for each parameter.
+
+    Returns:
+        Valid scalar parameter dictionaries for grid search.
+    """
+    param_names = list(parameter_ranges.keys())
+    param_values = [
+        list(value) if isinstance(value, range) else value
+        for value in parameter_ranges.values()
+    ]
+
+    return [
+        current_params
+        for params in itertools.product(*param_values)
+        if is_valid_strategy_params(
+            strategy_type, current_params := dict(zip(param_names, params))
+        )
+    ]
 
 
 def run_backtest(

--- a/src/quant_trading_strategy_backtester/strategies/mean_reversion.py
+++ b/src/quant_trading_strategy_backtester/strategies/mean_reversion.py
@@ -7,6 +7,9 @@ from typing import Any
 
 import polars as pl
 from quant_trading_strategy_backtester.strategies.base import BaseStrategy
+from quant_trading_strategy_backtester.strategy_params import (
+    validate_strategy_params,
+)
 
 
 class MeanReversionStrategy(BaseStrategy):
@@ -23,6 +26,7 @@ class MeanReversionStrategy(BaseStrategy):
     """
 
     def __init__(self, params: dict[str, Any]):
+        validate_strategy_params("Mean Reversion", params)
         super().__init__(params)
         # The number of days to calculate the moving average and standard
         # deviation.

--- a/src/quant_trading_strategy_backtester/strategies/moving_average_crossover.py
+++ b/src/quant_trading_strategy_backtester/strategies/moving_average_crossover.py
@@ -7,6 +7,9 @@ from typing import Any
 
 import polars as pl
 from quant_trading_strategy_backtester.strategies.base import BaseStrategy
+from quant_trading_strategy_backtester.strategy_params import (
+    validate_strategy_params,
+)
 
 
 class MovingAverageCrossoverStrategy(BaseStrategy):
@@ -22,6 +25,7 @@ class MovingAverageCrossoverStrategy(BaseStrategy):
     """
 
     def __init__(self, params: dict[str, Any]):
+        validate_strategy_params("Moving Average Crossover", params)
         super().__init__(params)
         # The number of days for the short-term and long-term moving average.
         self.short_window = int(params["short_window"])

--- a/src/quant_trading_strategy_backtester/strategies/pairs_trading.py
+++ b/src/quant_trading_strategy_backtester/strategies/pairs_trading.py
@@ -8,6 +8,9 @@ from typing import Any
 
 import polars as pl
 from quant_trading_strategy_backtester.strategies.base import BaseStrategy
+from quant_trading_strategy_backtester.strategy_params import (
+    validate_strategy_params,
+)
 
 
 class PairsTradingStrategy(BaseStrategy):
@@ -24,6 +27,7 @@ class PairsTradingStrategy(BaseStrategy):
     """
 
     def __init__(self, params: dict[str, Any]):
+        validate_strategy_params("Pairs Trading", params)
         super().__init__(params)
         # The lookback period for calculating the rolling mean and standard
         # deviation of the spread.

--- a/src/quant_trading_strategy_backtester/strategy_params.py
+++ b/src/quant_trading_strategy_backtester/strategy_params.py
@@ -1,0 +1,90 @@
+"""
+Validate trading strategy parameter dictionaries.
+"""
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def validate_strategy_params(strategy_type: str, params: Mapping[str, Any]) -> None:
+    """
+    Validate strategy parameters for a concrete strategy instance.
+
+    Args:
+        strategy_type: The strategy name.
+        params: Scalar parameter values for the strategy.
+
+    Raises:
+        ValueError: If any required parameter is missing or invalid.
+    """
+    match strategy_type:
+        case "Buy and Hold":
+            return
+        case "Moving Average Crossover":
+            short_window = _require_positive_int(params, "short_window")
+            long_window = _require_positive_int(params, "long_window")
+            if short_window >= long_window:
+                raise ValueError("short_window must be less than long_window")
+        case "Mean Reversion":
+            _require_positive_int(params, "window")
+            _require_positive_float(params, "std_dev")
+        case "Pairs Trading":
+            _require_positive_int(params, "window")
+            entry_z_score = _require_positive_float(params, "entry_z_score")
+            exit_z_score = _require_positive_float(params, "exit_z_score")
+            if exit_z_score >= entry_z_score:
+                raise ValueError("exit_z_score must be less than entry_z_score")
+        case _:
+            raise ValueError(f"Unexpected strategy type: {strategy_type}")
+
+
+def is_valid_strategy_params(strategy_type: str, params: Mapping[str, Any]) -> bool:
+    """
+    Return whether a strategy parameter dictionary is valid.
+
+    Args:
+        strategy_type: The strategy name.
+        params: Scalar parameter values for the strategy.
+
+    Returns:
+        True when the parameter dictionary passes validation.
+    """
+    try:
+        validate_strategy_params(strategy_type, params)
+    except ValueError:
+        return False
+
+    return True
+
+
+def _require_positive_int(params: Mapping[str, Any], name: str) -> int:
+    """Return a required positive integer parameter."""
+    value = _require_number(params, name)
+    int_value = int(value)
+    if int_value != value:
+        raise ValueError(f"{name} must be an integer")
+    if int_value <= 0:
+        raise ValueError(f"{name} must be positive")
+
+    return int_value
+
+
+def _require_positive_float(params: Mapping[str, Any], name: str) -> float:
+    """Return a required positive numeric parameter."""
+    value = float(_require_number(params, name))
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+
+    return value
+
+
+def _require_number(params: Mapping[str, Any], name: str) -> int | float:
+    """Return a required non-boolean numeric parameter."""
+    if name not in params:
+        raise ValueError(f"Missing required parameter: {name}")
+
+    value = params[name]
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{name} must be numeric")
+
+    return value

--- a/src/quant_trading_strategy_backtester/streamlit_ui.py
+++ b/src/quant_trading_strategy_backtester/streamlit_ui.py
@@ -126,8 +126,12 @@ def get_fixed_params(strategy_type: str) -> dict[str, Any]:
             short_window = st.sidebar.slider(
                 "Short Window (Days)", min_value=5, max_value=50, value=20
             )
+            long_window_min = max(20, short_window + 1)
             long_window = st.sidebar.slider(
-                "Long Window (Days)", min_value=20, max_value=200, value=50
+                "Long Window (Days)",
+                min_value=long_window_min,
+                max_value=200,
+                value=max(50, long_window_min),
             )
             return {"short_window": short_window, "long_window": long_window}
         case "Mean Reversion":
@@ -145,8 +149,13 @@ def get_fixed_params(strategy_type: str) -> dict[str, Any]:
             entry_z_score = st.sidebar.slider(
                 "Entry Z-Score", min_value=1.0, max_value=3.0, value=2.0, step=0.1
             )
+            exit_z_score_max = min(1.5, round(entry_z_score - 0.1, 1))
             exit_z_score = st.sidebar.slider(
-                "Exit Z-Score", min_value=0.1, max_value=1.5, value=0.5, step=0.1
+                "Exit Z-Score",
+                min_value=0.1,
+                max_value=exit_z_score_max,
+                value=min(0.5, exit_z_score_max),
+                step=0.1,
             )
             return {
                 "window": window,

--- a/tests/strategies/test_mean_reversion.py
+++ b/tests/strategies/test_mean_reversion.py
@@ -5,6 +5,7 @@ Tests for the Mean Reversion strategy class.
 from datetime import date, timedelta
 
 import polars as pl
+import pytest
 from quant_trading_strategy_backtester.strategies.mean_reversion import (
     MeanReversionStrategy,
 )
@@ -15,6 +16,20 @@ def test_mean_reversion_strategy_initialisation() -> None:
     strategy = MeanReversionStrategy(params)
     assert strategy.window == 20
     assert strategy.std_dev == 2.0
+
+
+@pytest.mark.parametrize(
+    ("params", "error"),
+    [
+        ({"window": 0, "std_dev": 2.0}, "window must be positive"),
+        ({"window": 20, "std_dev": 0.0}, "std_dev must be positive"),
+    ],
+)
+def test_mean_reversion_rejects_invalid_parameters(
+    params: dict[str, float], error: str
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        MeanReversionStrategy(params)
 
 
 def test_mean_reversion_strategy_generate_signals(

--- a/tests/strategies/test_moving_average_crossover.py
+++ b/tests/strategies/test_moving_average_crossover.py
@@ -5,6 +5,7 @@ Tests for the Moving Average Crossover strategy class.
 from datetime import date, timedelta
 
 import polars as pl
+import pytest
 from quant_trading_strategy_backtester.strategies.moving_average_crossover import (
     MovingAverageCrossoverStrategy,
 )
@@ -15,6 +16,13 @@ def test_moving_average_crossover_strategy_initialisation() -> None:
     strategy = MovingAverageCrossoverStrategy(params)
     assert strategy.short_window == 5
     assert strategy.long_window == 20
+
+
+def test_moving_average_crossover_rejects_invalid_windows() -> None:
+    params = {"short_window": 20, "long_window": 20}
+
+    with pytest.raises(ValueError, match="short_window must be less"):
+        MovingAverageCrossoverStrategy(params)
 
 
 def test_moving_average_crossover_strategy_generate_signals(

--- a/tests/strategies/test_pairs_trading.py
+++ b/tests/strategies/test_pairs_trading.py
@@ -46,6 +46,13 @@ def test_pairs_trading_strategy_initialisation() -> None:
     assert strategy.exit_z_score == 0.5
 
 
+def test_pairs_trading_strategy_rejects_invalid_thresholds() -> None:
+    params = {"window": 20, "entry_z_score": 1.0, "exit_z_score": 1.0}
+
+    with pytest.raises(ValueError, match="exit_z_score must be less"):
+        PairsTradingStrategy(params)
+
+
 def test_pairs_trading_strategy_signal_generation() -> None:
     start_date = date(2020, 1, 1)
     end_date = date(2020, 4, 9)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -82,9 +82,7 @@ def test_load_yfinance_data_two_tickers_preserves_requested_order(
 
     def mock_download(*args, **kwargs):
         assert args[0] == ["AAPL", "MSFT"]
-        columns = pd.MultiIndex.from_tuples(
-            [("Close", "MSFT"), ("Close", "AAPL")]
-        )
+        columns = pd.MultiIndex.from_tuples([("Close", "MSFT"), ("Close", "AAPL")])
         return pd.DataFrame(
             [[200.0, 100.0], [201.0, 101.0], [202.0, 102.0]],
             index=dates,
@@ -108,9 +106,7 @@ def test_load_yfinance_data_two_tickers_handles_ticker_first_columns(
     dates = pd.date_range(start="1/1/2020", end="1/3/2020")
 
     def mock_download(*args, **kwargs):
-        columns = pd.MultiIndex.from_tuples(
-            [("AAPL", "Close"), ("MSFT", "Close")]
-        )
+        columns = pd.MultiIndex.from_tuples([("AAPL", "Close"), ("MSFT", "Close")])
         return pd.DataFrame(
             [[100.0, 200.0], [101.0, 201.0], [102.0, 202.0]],
             index=dates,
@@ -151,9 +147,7 @@ def test_load_yfinance_data_two_tickers_requires_both_close_columns(
     dates = pd.date_range(start="1/1/2020", end="1/3/2020")
 
     def mock_download(*args, **kwargs):
-        columns = pd.MultiIndex.from_tuples(
-            [("Close", "AAPL"), ("Open", "MSFT")]
-        )
+        columns = pd.MultiIndex.from_tuples([("Close", "AAPL"), ("Open", "MSFT")])
         return pd.DataFrame(
             [[100.0, 200.0], [101.0, 201.0], [102.0, 202.0]],
             index=dates,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -6,6 +6,7 @@ import datetime
 
 import pandas as pd
 import polars as pl
+import pytest
 from quant_trading_strategy_backtester.data import (
     get_full_company_name,
     is_same_company,
@@ -72,6 +73,100 @@ def test_load_yfinance_data_two_tickers(
     assert "Close_1" in data.columns
     assert "Close_2" in data.columns
     assert len(data) == 31
+
+
+def test_load_yfinance_data_two_tickers_preserves_requested_order(
+    monkeypatch,
+) -> None:
+    dates = pd.date_range(start="1/1/2020", end="1/3/2020")
+
+    def mock_download(*args, **kwargs):
+        assert args[0] == ["AAPL", "MSFT"]
+        columns = pd.MultiIndex.from_tuples(
+            [("Close", "MSFT"), ("Close", "AAPL")]
+        )
+        return pd.DataFrame(
+            [[200.0, 100.0], [201.0, 101.0], [202.0, 102.0]],
+            index=dates,
+            columns=columns,
+        )
+
+    monkeypatch.setattr("yfinance.download", mock_download)
+    load_yfinance_data_two_tickers.clear()
+
+    data = load_yfinance_data_two_tickers(
+        "AAPL", "MSFT", datetime.date(2020, 1, 1), datetime.date(2020, 1, 3)
+    )
+
+    assert data["Close_1"].to_list() == [100.0, 101.0, 102.0]
+    assert data["Close_2"].to_list() == [200.0, 201.0, 202.0]
+
+
+def test_load_yfinance_data_two_tickers_handles_ticker_first_columns(
+    monkeypatch,
+) -> None:
+    dates = pd.date_range(start="1/1/2020", end="1/3/2020")
+
+    def mock_download(*args, **kwargs):
+        columns = pd.MultiIndex.from_tuples(
+            [("AAPL", "Close"), ("MSFT", "Close")]
+        )
+        return pd.DataFrame(
+            [[100.0, 200.0], [101.0, 201.0], [102.0, 202.0]],
+            index=dates,
+            columns=columns,
+        )
+
+    monkeypatch.setattr("yfinance.download", mock_download)
+    load_yfinance_data_two_tickers.clear()
+
+    data = load_yfinance_data_two_tickers(
+        "AAPL", "MSFT", datetime.date(2020, 1, 1), datetime.date(2020, 1, 3)
+    )
+
+    assert data["Close_1"].to_list() == [100.0, 101.0, 102.0]
+    assert data["Close_2"].to_list() == [200.0, 201.0, 202.0]
+
+
+def test_load_yfinance_data_two_tickers_rejects_flat_response(
+    monkeypatch,
+) -> None:
+    dates = pd.date_range(start="1/1/2020", end="1/3/2020")
+
+    def mock_download(*args, **kwargs):
+        return pd.DataFrame({"Close": [100.0, 101.0, 102.0]}, index=dates)
+
+    monkeypatch.setattr("yfinance.download", mock_download)
+    load_yfinance_data_two_tickers.clear()
+
+    with pytest.raises(ValueError, match="Expected MultiIndex columns"):
+        load_yfinance_data_two_tickers(
+            "AAPL", "MSFT", datetime.date(2020, 1, 1), datetime.date(2020, 1, 3)
+        )
+
+
+def test_load_yfinance_data_two_tickers_requires_both_close_columns(
+    monkeypatch,
+) -> None:
+    dates = pd.date_range(start="1/1/2020", end="1/3/2020")
+
+    def mock_download(*args, **kwargs):
+        columns = pd.MultiIndex.from_tuples(
+            [("Close", "AAPL"), ("Open", "MSFT")]
+        )
+        return pd.DataFrame(
+            [[100.0, 200.0], [101.0, 201.0], [102.0, 202.0]],
+            index=dates,
+            columns=columns,
+        )
+
+    monkeypatch.setattr("yfinance.download", mock_download)
+    load_yfinance_data_two_tickers.clear()
+
+    with pytest.raises(ValueError, match="Expected exactly one Close column for MSFT"):
+        load_yfinance_data_two_tickers(
+            "AAPL", "MSFT", datetime.date(2020, 1, 1), datetime.date(2020, 1, 3)
+        )
 
 
 def test_get_full_company_name_success(monkeypatch):

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -940,6 +940,59 @@ def test_optimise_strategy_params_returns_test_metrics(monkeypatch):
     assert metrics["Total Return"] == 0.05
 
 
+def test_optimise_strategy_params_skips_invalid_parameter_combinations(
+    monkeypatch,
+) -> None:
+    """Verify optimisation does not run backtests for invalid grid values."""
+    data = pl.DataFrame(
+        {
+            "Date": [datetime.date(2020, 1, i) for i in range(1, 22)],
+            "Close": [100 + i for i in range(21)],
+        }
+    )
+    evaluated_params = []
+
+    def mock_run_backtest(data, strategy_type, params, tickers):
+        evaluated_params.append(params)
+        return None, {
+            "Sharpe Ratio": 1.0,
+            "Total Return": 0.1,
+            "Max Drawdown": -0.05,
+        }
+
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.run_backtest", mock_run_backtest
+    )
+
+    params, _ = optimise_strategy_params(
+        data,
+        "Moving Average Crossover",
+        {"short_window": [10, 30], "long_window": [20]},
+        "AAPL",
+    )
+
+    assert evaluated_params == [{"short_window": 10, "long_window": 20}]
+    assert params == {"short_window": 10, "long_window": 20}
+
+
+def test_optimise_strategy_params_raises_when_all_combinations_are_invalid() -> None:
+    """Verify optimisation reports invalid grids before running backtests."""
+    data = pl.DataFrame(
+        {
+            "Date": [datetime.date(2020, 1, i) for i in range(1, 22)],
+            "Close": [100 + i for i in range(21)],
+        }
+    )
+
+    with pytest.raises(ValueError, match="No valid parameter combinations"):
+        optimise_strategy_params(
+            data,
+            "Pairs Trading",
+            {"window": [20], "entry_z_score": [1.0], "exit_z_score": [1.0]},
+            ["AAPL", "MSFT"],
+        )
+
+
 def test_optimise_buy_and_hold_ticker_uses_train_test_split(monkeypatch):
     """Verify buy-and-hold ticker selection uses train for ranking, test for eval."""
     mock_top_companies = [("AAPL", 1000000.0), ("GOOGL", 900000.0)]


### PR DESCRIPTION
# Summary
- Hardened market-data loading for multi-ticker Yahoo responses
  - Kept pair data aligned to requested ticker order instead of relying on yfinance column order
  - Treated malformed or incomplete responses as explicit data errors
- Added shared strategy-parameter validation across direct strategy construction and optimisation
  - Invalid moving-average windows and pairs thresholds no longer enter fixed runs, optimiser grids, or walk-forward searches
- Tightened Streamlit controls so users cannot select invalid fixed parameter combinations
- Expanded regression coverage around yfinance response shapes and invalid optimisation grids

## Rationale
- yfinance can return either price-first or ticker-first `MultiIndex` layouts, and positional renaming was silently capable of swapping pair legs
- Filtering optimiser grids before running backtests keeps progress counts and failure modes honest
  - Constructor validation remains the hard stop for direct use and non-UI callers

## Manual Test Evidence
- Ran local Streamlit smoke through default buy-and-hold, moving-average, and pairs paths after the input-boundary changes
  - The app rendered strategy results without browser console errors or Streamlit tracebacks