### PR TITLE
feat: Add trade ledger, cost attribution, and contextual validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ _Try the deployed app
   and stock selection from S&P 500
 - **Transaction costs and slippage modelling** – configurable fees and slippage
   for realistic performance estimates
+- **Trade ledger and cost attribution** – explicit trade events, turnover,
+  gross/net returns, and cumulative cost drag
 - **Efficient data processing** – vectorised computation using Polars for
   improved performance
 - **Interactive web-based dashboard** – Streamlit UI for strategy configuration,

--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -94,6 +94,77 @@ def _get_final_backtest_data(
     return validation_data
 
 
+def _get_final_backtest_results(
+    results: pl.DataFrame,
+    final_backtest_data: pl.DataFrame,
+    use_validation_data: bool,
+    initial_capital: float = 100000.0,
+) -> pl.DataFrame:
+    """
+    Return final results while preserving rolling context for validation.
+
+    Args:
+        results: Backtest results calculated over the full context data.
+        final_backtest_data: Rows to display and score.
+        use_validation_data: Whether final results should be limited to
+            validation rows.
+        initial_capital: Capital used to reset the displayed equity curve.
+
+    Returns:
+        Full results for plain backtests, or validation-period rows with
+        cumulative columns reset to the validation start.
+    """
+    if not use_validation_data:
+        return results
+
+    if final_backtest_data.is_empty():
+        return results.head(0)
+
+    validation_dates = final_backtest_data.select(pl.col("Date").unique())
+    final_results = results.join(validation_dates, on="Date", how="inner")
+    return _reset_cumulative_result_columns(final_results, initial_capital)
+
+
+def _reset_cumulative_result_columns(
+    results: pl.DataFrame, initial_capital: float
+) -> pl.DataFrame:
+    """Reset cumulative returns and costs from the first displayed row."""
+    if results.is_empty():
+        return results
+
+    return results.with_columns(
+        [
+            (1 + pl.col("gross_strategy_returns"))
+            .cum_prod()
+            .alias("gross_cumulative_returns"),
+            (1 + pl.col("strategy_returns")).cum_prod().alias("cumulative_returns"),
+            (initial_capital * (1 + pl.col("strategy_returns")).cum_prod()).alias(
+                "equity_curve"
+            ),
+            pl.col("transaction_costs").cum_sum().alias("cumulative_transaction_costs"),
+        ]
+    )
+
+
+def _get_performance_metrics_for_results(
+    data: pl.DataFrame,
+    strategy_type: str,
+    strategy_params: dict[str, Any],
+    tickers: str | list[str],
+    results: pl.DataFrame,
+) -> dict[str, float]:
+    """Return performance metrics for an already-calculated result set."""
+    strategy = create_strategy(strategy_type, strategy_params)
+    backtester = Backtester(data, strategy, tickers=tickers)
+    backtester.results = results
+    metrics = backtester.get_performance_metrics()
+    assert metrics is not None, (
+        "No results available for the selected ticker and date range"
+    )
+
+    return metrics
+
+
 # Trading strategy preparation functions
 
 
@@ -637,8 +708,15 @@ def main():
         st.write("No validation data available for the selected ticker and date range")
         return
 
-    results, metrics = _cached_run_backtest(
-        backtest_data, strategy_type, strategy_params, tickers
+    context_data = data if use_validation_data else backtest_data
+    context_results, _ = _cached_run_backtest(
+        context_data, strategy_type, strategy_params, tickers
+    )
+    results = _get_final_backtest_results(
+        context_results, backtest_data, use_validation_data
+    )
+    metrics = _get_performance_metrics_for_results(
+        backtest_data, strategy_type, strategy_params, tickers, results
     )
 
     # Save only the final backtest result, and only once per unique
@@ -650,6 +728,12 @@ def main():
         backtester.results = results
         backtester.save_results()
         st.session_state["_last_saved_key"] = _save_key
+
+    if use_validation_data and metrics.get("Trade Events", 1.0) == 0:
+        st.warning(
+            "The selected strategy produced no trades over the displayed "
+            "validation period, so risk-adjusted metrics may be undefined."
+        )
 
     display_performance_metrics(metrics, company_display)
     plot_equity_curve(

--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -45,6 +45,7 @@ from quant_trading_strategy_backtester.utils import (
 from quant_trading_strategy_backtester.visualisation import (
     display_performance_metrics,
     display_returns_by_month,
+    display_trade_ledger,
     plot_equity_curve,
     plot_pairs_spread,
     plot_strategy_returns,
@@ -667,6 +668,7 @@ def main():
         )
     plot_strategy_returns(results, ticker_display, company_display)
     display_returns_by_month(results)
+    display_trade_ledger(results)
 
     # Display the raw data from Yahoo Finance for the backtest period
     st.header(f"Raw Data for {company_display}")

--- a/src/quant_trading_strategy_backtester/backtester.py
+++ b/src/quant_trading_strategy_backtester/backtester.py
@@ -10,6 +10,7 @@ this repository.
 import json
 import platform
 from datetime import date, datetime
+from typing import Any
 
 import polars as pl
 import streamlit as st
@@ -19,6 +20,25 @@ from quant_trading_strategy_backtester.models import StrategyModel as StrategyMo
 from quant_trading_strategy_backtester.strategies.base import BaseStrategy
 
 TRADING_DAYS_PER_YEAR = 252
+
+TRADE_LEDGER_SCHEMA = {
+    "Date": pl.Date,
+    "Action": pl.Utf8,
+    "Reason": pl.Utf8,
+    "Signal": pl.Float64,
+    "Previous Signal": pl.Float64,
+    "Position Change": pl.Float64,
+    "Turnover": pl.Float64,
+    "Gross Return": pl.Float64,
+    "Transaction Costs": pl.Float64,
+    "Net Return": pl.Float64,
+    "Cumulative Costs": pl.Float64,
+    "Equity": pl.Float64,
+    "Holding Period Days": pl.Int64,
+    "Leg 1 Weight": pl.Float64,
+    "Leg 2 Weight": pl.Float64,
+    "Z-Score": pl.Float64,
+}
 
 
 def is_running_locally() -> bool:
@@ -31,6 +51,148 @@ def is_running_locally() -> bool:
         bool: True if running locally, False if running on Streamlit Cloud
     """
     return bool(platform.processor())
+
+
+def build_trade_ledger(results: pl.DataFrame) -> pl.DataFrame:
+    """
+    Build a row-level trade ledger from backtest results.
+
+    Args:
+        results: The backtest results DataFrame.
+
+    Returns:
+        A DataFrame containing rows where position or leg exposure changed.
+    """
+    if results.is_empty():
+        return pl.DataFrame(schema=TRADE_LEDGER_SCHEMA)
+
+    required_columns = {
+        "Date",
+        "signal",
+        "position_change",
+        "trade_turnover",
+        "gross_strategy_returns",
+        "transaction_costs",
+        "strategy_returns",
+        "cumulative_transaction_costs",
+        "equity_curve",
+    }
+    missing_columns = required_columns - set(results.columns)
+    if missing_columns:
+        raise ValueError(
+            f"Trade ledger requires backtest result columns: {sorted(missing_columns)}"
+        )
+
+    records: list[dict[str, Any]] = []
+    position_start_date: date | datetime | None = None
+    previous_signal = 0.0
+
+    for row in results.iter_rows(named=True):
+        signal = float(row["signal"] or 0.0)
+        position_change = float(row["position_change"] or 0.0)
+        turnover = float(row["trade_turnover"] or 0.0)
+
+        if turnover <= 0 and abs(position_change) <= 0:
+            previous_signal = signal
+            continue
+
+        current_date = _normalise_trade_date(row["Date"])
+        action = _classify_trade_action(previous_signal, signal, turnover)
+        holding_period_days = _calculate_holding_period_days(
+            current_date, position_start_date
+        )
+
+        records.append(
+            {
+                "Date": current_date,
+                "Action": action,
+                "Reason": _classify_trade_reason(row, action),
+                "Signal": signal,
+                "Previous Signal": previous_signal,
+                "Position Change": position_change,
+                "Turnover": turnover,
+                "Gross Return": float(row["gross_strategy_returns"] or 0.0),
+                "Transaction Costs": float(row["transaction_costs"] or 0.0),
+                "Net Return": float(row["strategy_returns"] or 0.0),
+                "Cumulative Costs": float(row["cumulative_transaction_costs"] or 0.0),
+                "Equity": float(row["equity_curve"] or 0.0),
+                "Holding Period Days": holding_period_days,
+                "Leg 1 Weight": _optional_float(row, "leg_1_weight"),
+                "Leg 2 Weight": _optional_float(row, "leg_2_weight"),
+                "Z-Score": _optional_float(row, "z_score"),
+            }
+        )
+
+        if previous_signal == 0 and signal != 0:
+            position_start_date = current_date
+        elif previous_signal != 0 and signal == 0:
+            position_start_date = None
+        elif previous_signal * signal < 0:
+            position_start_date = current_date
+
+        previous_signal = signal
+
+    return pl.DataFrame(records, schema=TRADE_LEDGER_SCHEMA)
+
+
+def _classify_trade_action(
+    previous_signal: float, signal: float, turnover: float
+) -> str:
+    """Classify a trade event from previous and current exposure."""
+    if previous_signal == 0 and signal > 0:
+        return "Enter Long"
+    if previous_signal == 0 and signal < 0:
+        return "Enter Short"
+    if previous_signal > 0 and signal == 0:
+        return "Exit Long"
+    if previous_signal < 0 and signal == 0:
+        return "Exit Short"
+    if previous_signal > 0 and signal < 0:
+        return "Flip Long To Short"
+    if previous_signal < 0 and signal > 0:
+        return "Flip Short To Long"
+    if turnover > 0 and signal != 0:
+        return "Rebalance"
+
+    return "Trade"
+
+
+def _classify_trade_reason(row: dict[str, Any], action: str) -> str:
+    """Return the signal reason for a trade ledger row."""
+    if action == "Rebalance":
+        return "Leg weights changed"
+    if row.get("z_score") is not None:
+        return "Pairs z-score signal"
+
+    return "Strategy signal changed"
+
+
+def _calculate_holding_period_days(
+    current_date: date | datetime,
+    position_start_date: date | datetime | None,
+) -> int | None:
+    """Return position age in calendar days for open or closing trades."""
+    if position_start_date is None:
+        return None
+
+    return (current_date - position_start_date).days
+
+
+def _normalise_trade_date(value: date | datetime) -> date:
+    """Return a plain date for ledger display and schema construction."""
+    if isinstance(value, datetime):
+        return value.date()
+
+    return value
+
+
+def _optional_float(row: dict[str, Any], name: str) -> float | None:
+    """Return an optional row value as a float."""
+    value = row.get(name)
+    if value is None:
+        return None
+
+    return float(value)
 
 
 class Backtester:
@@ -122,6 +284,7 @@ class Backtester:
         asset_returns = (self.data["Close"] - self.data["Close"].shift(1)) / self.data[
             "Close"
         ].shift(1)
+        cost_rate = (self.transaction_cost_bps + self.slippage_bps) / 10_000
 
         portfolio = (
             signals.lazy()
@@ -130,26 +293,28 @@ class Backtester:
                     pl.col("position_change"),
                     asset_returns.alias("asset_returns"),
                     (pl.col("signal").shift(1) * asset_returns).alias(
-                        "strategy_returns"
+                        "gross_strategy_returns"
                     ),
                 ]
             )
             # Handle potential NaN or inf values.
             .with_columns(
                 [
-                    pl.col("strategy_returns")
+                    pl.col("gross_strategy_returns")
                     .replace({float("inf"): None, float("-inf"): None})
                     .fill_null(0)
+                    .alias("gross_strategy_returns"),
+                    pl.col("position_change").abs().alias("trade_turnover"),
                 ]
             )
             # Deduct transaction costs and slippage on position changes.
             .with_columns(
                 [
+                    (pl.col("trade_turnover") * cost_rate).alias("transaction_costs"),
                     (
-                        pl.col("strategy_returns")
-                        - pl.col("position_change").abs()
-                        * ((self.transaction_cost_bps + self.slippage_bps) / 10_000)
-                    ).alias("strategy_returns")
+                        pl.col("gross_strategy_returns")
+                        - pl.col("trade_turnover") * cost_rate
+                    ).alias("strategy_returns"),
                 ]
             )
         )
@@ -209,27 +374,31 @@ class Backtester:
                         * pl.col("asset_1_returns")
                         + pl.col("leg_2_weight").shift(1).fill_null(0)
                         * pl.col("asset_2_returns")
-                    ).alias("strategy_returns"),
+                    ).alias("gross_strategy_returns"),
                     (
                         pl.col("leg_1_weight_change").abs()
                         + pl.col("leg_2_weight_change").abs()
-                    ).alias("pair_turnover"),
+                    ).alias("trade_turnover"),
                 ]
             )
             # Handle potential NaN or inf values.
             .with_columns(
                 [
-                    pl.col("strategy_returns")
+                    pl.col("gross_strategy_returns")
                     .replace({float("inf"): None, float("-inf"): None})
                     .fill_null(0)
+                    .alias("gross_strategy_returns"),
+                    pl.col("trade_turnover").alias("pair_turnover"),
                 ]
             )
             # Deduct transaction costs and slippage on leg turnover.
             .with_columns(
                 [
+                    (pl.col("trade_turnover") * cost_rate).alias("transaction_costs"),
                     (
-                        pl.col("strategy_returns") - pl.col("pair_turnover") * cost_rate
-                    ).alias("strategy_returns")
+                        pl.col("gross_strategy_returns")
+                        - pl.col("trade_turnover") * cost_rate
+                    ).alias("strategy_returns"),
                 ]
             )
         )
@@ -240,10 +409,16 @@ class Backtester:
         """Add cumulative returns and equity curve columns."""
         result = portfolio.with_columns(
             [
+                (1 + pl.col("gross_strategy_returns"))
+                .cum_prod()
+                .alias("gross_cumulative_returns"),
                 (1 + pl.col("strategy_returns")).cum_prod().alias("cumulative_returns"),
                 (
                     self.initial_capital * (1 + pl.col("strategy_returns")).cum_prod()
                 ).alias("equity_curve"),
+                pl.col("transaction_costs")
+                .cum_sum()
+                .alias("cumulative_transaction_costs"),
             ]
         ).collect()
         if not isinstance(result, pl.DataFrame):
@@ -277,6 +452,15 @@ class Backtester:
             float(self.results["cumulative_returns"].cast(pl.Float64).tail(1).item())
             - 1
         )
+        gross_total_return = (
+            float(
+                self.results["gross_cumulative_returns"].cast(pl.Float64).tail(1).item()
+            )
+            - 1
+        )
+        total_costs = float(self.results["transaction_costs"].cast(pl.Float64).sum())
+        total_turnover = float(self.results["trade_turnover"].cast(pl.Float64).sum())
+        trade_events = float(self.results.filter(pl.col("trade_turnover") > 0).height)
 
         # Measure the risk-adjusted return.
         periods = TRADING_DAYS_PER_YEAR
@@ -299,8 +483,13 @@ class Backtester:
         # TODO: Split the calculations out into separate functions.
         return {
             "Total Return": total_return,
+            "Gross Total Return": gross_total_return,
             "Sharpe Ratio": sharpe_ratio,
             "Max Drawdown": max_drawdown,
+            "Total Costs": total_costs,
+            "Cost Drag": gross_total_return - total_return,
+            "Trade Events": trade_events,
+            "Total Turnover": total_turnover,
         }
 
     def save_results(self) -> None:

--- a/src/quant_trading_strategy_backtester/optimiser.py
+++ b/src/quant_trading_strategy_backtester/optimiser.py
@@ -5,6 +5,7 @@ parameters and ticker pairs.
 
 import datetime
 import itertools
+import math
 import time
 from typing import Any, cast
 
@@ -84,6 +85,17 @@ def get_validation_data(
 
     _, test_data = _split_data(data)
     return test_data
+
+
+def _optimisation_score(
+    metrics: dict[str, float], metric_name: str = "Sharpe Ratio"
+) -> float | None:
+    """Return a finite optimisation score, or None for invalid metrics."""
+    score = metrics.get(metric_name)
+    if score is None or not math.isfinite(score):
+        return None
+
+    return score
 
 
 def run_optimisation(
@@ -219,8 +231,12 @@ def optimise_buy_and_hold_ticker(
         backtester.run()
         train_metrics = backtester.get_performance_metrics()
 
-        if train_metrics and train_metrics["Total Return"] > best_total_return:
-            best_total_return = train_metrics["Total Return"]
+        if train_metrics is None:
+            continue
+
+        total_return = _optimisation_score(train_metrics, "Total Return")
+        if total_return is not None and total_return > best_total_return:
+            best_total_return = total_return
             best_ticker = ticker
             best_test_data = test_data
 
@@ -287,8 +303,9 @@ def optimise_single_ticker_strategy_ticker(
         train_data, _ = _split_data(data)
         _, train_metrics = run_backtest(train_data, strategy_type, fixed_params, ticker)
 
-        if train_metrics["Sharpe Ratio"] > best_sharpe_ratio:
-            best_sharpe_ratio = train_metrics["Sharpe Ratio"]
+        score = _optimisation_score(train_metrics)
+        if score is not None and score > best_sharpe_ratio:
+            best_sharpe_ratio = score
             best_ticker = ticker
 
     progress_bar.empty()
@@ -347,8 +364,9 @@ def optimise_strategy_params(
 
         _, metrics = run_backtest(data, strategy_type, current_params, tickers)
 
-        if metrics["Sharpe Ratio"] > best_sharpe_ratio:
-            best_sharpe_ratio = metrics["Sharpe Ratio"]
+        score = _optimisation_score(metrics)
+        if score is not None and score > best_sharpe_ratio:
+            best_sharpe_ratio = score
             best_params = current_params
             best_metrics = metrics
 
@@ -441,8 +459,9 @@ def optimise_pairs_trading_tickers(
             )
             current_params = strategy_params
 
-        if train_metrics["Sharpe Ratio"] > best_sharpe_ratio:
-            best_sharpe_ratio = train_metrics["Sharpe Ratio"]
+        score = _optimisation_score(train_metrics)
+        if score is not None and score > best_sharpe_ratio:
+            best_sharpe_ratio = score
             best_pair = (ticker1, ticker2)
             best_params = current_params
             best_test_data = test_data
@@ -518,8 +537,9 @@ def walk_forward_optimise(
             _, metrics = run_backtest(
                 train_data, strategy_type, current_params, tickers
             )
-            if metrics["Sharpe Ratio"] > best_sharpe:
-                best_sharpe = metrics["Sharpe Ratio"]
+            score = _optimisation_score(metrics)
+            if score is not None and score > best_sharpe:
+                best_sharpe = score
                 best_params = current_params
 
         if best_params is None:

--- a/src/quant_trading_strategy_backtester/visualisation.py
+++ b/src/quant_trading_strategy_backtester/visualisation.py
@@ -6,6 +6,8 @@ import plotly.graph_objects as go
 import polars as pl
 import streamlit as st
 
+from quant_trading_strategy_backtester.backtester import build_trade_ledger
+
 
 def display_performance_metrics(
     metrics: dict[str, float], company_name: str | None
@@ -22,6 +24,24 @@ def display_performance_metrics(
     total_return_col.metric("Total Return", f"{metrics['Total Return']:.4%}")
     sharpe_ratio_col.metric("Sharpe Ratio", f"{metrics['Sharpe Ratio']:.4f}")
     max_drawdown_col.metric("Max Drawdown", f"{metrics['Max Drawdown']:.4%}")
+
+    if {
+        "Gross Total Return",
+        "Total Costs",
+        "Cost Drag",
+        "Trade Events",
+        "Total Turnover",
+    }.issubset(metrics):
+        gross_return_col, cost_drag_col, total_costs_col = st.columns(3)
+        gross_return_col.metric(
+            "Gross Total Return", f"{metrics['Gross Total Return']:.4%}"
+        )
+        cost_drag_col.metric("Cost Drag", f"{metrics['Cost Drag']:.4%}")
+        total_costs_col.metric("Total Costs", f"{metrics['Total Costs']:.4%}")
+
+        trade_events_col, turnover_col, _ = st.columns(3)
+        trade_events_col.metric("Trade Events", f"{metrics['Trade Events']:.0f}")
+        turnover_col.metric("Total Turnover", f"{metrics['Total Turnover']:.4f}")
 
 
 def plot_equity_curve(
@@ -261,3 +281,76 @@ def display_returns_by_month(results: pl.DataFrame) -> None:
             width="content",
             hide_index=True,
         )
+
+
+def display_trade_ledger(results: pl.DataFrame) -> None:
+    """
+    Display cost attribution and trade ledger rows from backtest results.
+
+    Args:
+        results: The backtest results DataFrame.
+    """
+    st.subheader("Cost Attribution")
+    if results.is_empty():
+        st.write("No data available for cost attribution.")
+        return
+
+    total_costs = float(results["transaction_costs"].cast(pl.Float64).sum())
+    total_turnover = float(results["trade_turnover"].cast(pl.Float64).sum())
+    trade_events = results.filter(pl.col("trade_turnover") > 0).height
+
+    costs_col, turnover_col, events_col = st.columns(3)
+    costs_col.metric("Total Costs", f"{total_costs:.4%}")
+    turnover_col.metric("Total Turnover", f"{total_turnover:.4f}")
+    events_col.metric("Trade Events", f"{trade_events}")
+
+    st.subheader("Trade Ledger")
+    ledger = build_trade_ledger(results)
+    if ledger.is_empty():
+        st.write("No trades were generated for this backtest.")
+        return
+
+    display_columns = [
+        "Date",
+        "Action",
+        "Reason",
+        "Signal",
+        "Turnover",
+        "Gross Return",
+        "Transaction Costs",
+        "Net Return",
+        "Cumulative Costs",
+        "Equity",
+        "Holding Period Days",
+    ]
+    optional_columns = ["Leg 1 Weight", "Leg 2 Weight", "Z-Score"]
+    display_columns.extend(
+        column
+        for column in optional_columns
+        if column in ledger.columns and ledger[column].null_count() < ledger.height
+    )
+
+    ledger_display = ledger.select(display_columns).with_columns(
+        [
+            pl.col("Turnover").round(4),
+            (pl.col("Gross Return") * 100).round(4).alias("Gross Return (%)"),
+            (pl.col("Transaction Costs") * 100).round(4).alias("Transaction Costs (%)"),
+            (pl.col("Net Return") * 100).round(4).alias("Net Return (%)"),
+            (pl.col("Cumulative Costs") * 100).round(4).alias("Cumulative Costs (%)"),
+            pl.col("Equity").round(2),
+        ]
+    )
+    ledger_display = ledger_display.drop(
+        [
+            "Gross Return",
+            "Transaction Costs",
+            "Net Return",
+            "Cumulative Costs",
+        ]
+    )
+
+    st.dataframe(
+        ledger_display.to_pandas(),
+        width="stretch",
+        hide_index=True,
+    )

--- a/src/quant_trading_strategy_backtester/visualisation.py
+++ b/src/quant_trading_strategy_backtester/visualisation.py
@@ -2,11 +2,21 @@
 Contains functions to display backtest results using Streamlit and Plotly.
 """
 
+import math
+
 import plotly.graph_objects as go
 import polars as pl
 import streamlit as st
 
 from quant_trading_strategy_backtester.backtester import build_trade_ledger
+
+
+def _format_metric(value: float, format_spec: str) -> str:
+    """Format finite metrics and display undefined metrics clearly."""
+    if not math.isfinite(value):
+        return "N/A"
+
+    return f"{value:{format_spec}}"
 
 
 def display_performance_metrics(
@@ -21,9 +31,15 @@ def display_performance_metrics(
     """
     st.header(f"Backtest Results for {company_name}")
     total_return_col, sharpe_ratio_col, max_drawdown_col = st.columns(3)
-    total_return_col.metric("Total Return", f"{metrics['Total Return']:.4%}")
-    sharpe_ratio_col.metric("Sharpe Ratio", f"{metrics['Sharpe Ratio']:.4f}")
-    max_drawdown_col.metric("Max Drawdown", f"{metrics['Max Drawdown']:.4%}")
+    total_return_col.metric(
+        "Total Return", _format_metric(metrics["Total Return"], ".4%")
+    )
+    sharpe_ratio_col.metric(
+        "Sharpe Ratio", _format_metric(metrics["Sharpe Ratio"], ".4f")
+    )
+    max_drawdown_col.metric(
+        "Max Drawdown", _format_metric(metrics["Max Drawdown"], ".4%")
+    )
 
     if {
         "Gross Total Return",
@@ -34,14 +50,21 @@ def display_performance_metrics(
     }.issubset(metrics):
         gross_return_col, cost_drag_col, total_costs_col = st.columns(3)
         gross_return_col.metric(
-            "Gross Total Return", f"{metrics['Gross Total Return']:.4%}"
+            "Gross Total Return",
+            _format_metric(metrics["Gross Total Return"], ".4%"),
         )
-        cost_drag_col.metric("Cost Drag", f"{metrics['Cost Drag']:.4%}")
-        total_costs_col.metric("Total Costs", f"{metrics['Total Costs']:.4%}")
+        cost_drag_col.metric("Cost Drag", _format_metric(metrics["Cost Drag"], ".4%"))
+        total_costs_col.metric(
+            "Total Costs", _format_metric(metrics["Total Costs"], ".4%")
+        )
 
         trade_events_col, turnover_col, _ = st.columns(3)
-        trade_events_col.metric("Trade Events", f"{metrics['Trade Events']:.0f}")
-        turnover_col.metric("Total Turnover", f"{metrics['Total Turnover']:.4f}")
+        trade_events_col.metric(
+            "Trade Events", _format_metric(metrics["Trade Events"], ".0f")
+        )
+        turnover_col.metric(
+            "Total Turnover", _format_metric(metrics["Total Turnover"], ".4f")
+        )
 
 
 def plot_equity_curve(

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import polars as pl
 import pytest
-from quant_trading_strategy_backtester.backtester import Backtester
+from quant_trading_strategy_backtester.backtester import Backtester, build_trade_ledger
 from quant_trading_strategy_backtester.models import StrategyModel
 from quant_trading_strategy_backtester.strategies.base import BaseStrategy
 from quant_trading_strategy_backtester.strategies.buy_and_hold import BuyAndHoldStrategy
@@ -124,7 +124,17 @@ def test_backtester_run(
     backtester = Backtester(data, strategy)
     results = backtester.run()
     assert isinstance(results, pl.DataFrame)
-    EXPECTED_COLS = {"position_change", "strategy_returns", "equity_curve"}
+    EXPECTED_COLS = {
+        "position_change",
+        "gross_strategy_returns",
+        "transaction_costs",
+        "strategy_returns",
+        "trade_turnover",
+        "cumulative_transaction_costs",
+        "gross_cumulative_returns",
+        "cumulative_returns",
+        "equity_curve",
+    }
     for col in EXPECTED_COLS:
         assert col in results.columns
 
@@ -157,7 +167,16 @@ def test_backtester_get_performance_metrics(
     backtester.run()
     metrics = backtester.get_performance_metrics()
     assert isinstance(metrics, dict)
-    EXPECTED_METRICS = {"Total Return", "Sharpe Ratio", "Max Drawdown"}
+    EXPECTED_METRICS = {
+        "Total Return",
+        "Gross Total Return",
+        "Sharpe Ratio",
+        "Max Drawdown",
+        "Total Costs",
+        "Cost Drag",
+        "Trade Events",
+        "Total Turnover",
+    }
     for metric in EXPECTED_METRICS:
         assert metric in metrics
 
@@ -385,6 +404,42 @@ def test_transaction_costs_reduce_returns():
         )
 
 
+def test_backtester_reports_cost_attribution_metrics():
+    """
+    Verify that performance metrics include gross returns and cost drag.
+    """
+    data = pl.DataFrame(
+        {
+            "Date": [
+                datetime.date(2020, 1, 1),
+                datetime.date(2020, 1, 2),
+                datetime.date(2020, 1, 3),
+                datetime.date(2020, 1, 4),
+            ],
+            "Close": [100.0, 110.0, 121.0, 133.1],
+        }
+    )
+    signals = [0.0, 1.0, 1.0, 0.0]
+    strategy = MockHoldingStrategy({"signals": signals})
+    backtester = Backtester(data, strategy, transaction_cost_bps=10.0, slippage_bps=5.0)
+
+    results = backtester.run()
+    metrics = backtester.get_performance_metrics()
+    assert metrics is not None
+
+    assert results["gross_strategy_returns"].to_list() == pytest.approx(
+        [0.0, 0.0, 0.1, 0.1]
+    )
+    assert results["transaction_costs"].to_list() == pytest.approx(
+        [0.0, 0.0015, 0.0, 0.0015]
+    )
+    assert metrics["Gross Total Return"] > metrics["Total Return"]
+    assert metrics["Total Costs"] == pytest.approx(0.003)
+    assert metrics["Cost Drag"] > 0
+    assert metrics["Trade Events"] == 2
+    assert metrics["Total Turnover"] == 2
+
+
 def test_default_transaction_costs_reduce_returns():
     """
     Verify that the default transaction costs (5bps each) produce
@@ -520,7 +575,105 @@ def test_pairs_costs_use_leg_weight_changes():
 
     cost_rate = 15.0 / 10_000
     assert results["pair_turnover"].to_list() == pytest.approx([0.0, 1.0, 1 / 3, 0.0])
+    assert results["trade_turnover"].to_list() == pytest.approx([0.0, 1.0, 1 / 3, 0.0])
+    assert results["transaction_costs"].to_list() == pytest.approx(
+        [0.0, cost_rate, cost_rate / 3, 0.0]
+    )
     assert results["strategy_returns"].to_list() == pytest.approx(
         [0.0, -cost_rate, -(cost_rate / 3), 0.0]
     )
     assert results["position_change"].to_list() == [0.0, 1.0, 0.0, 0.0]
+
+
+def test_trade_ledger_records_single_asset_entries_and_exits():
+    """
+    Verify that the trade ledger captures entry, exit, costs, and holding time.
+    """
+    data = pl.DataFrame(
+        {
+            "Date": [
+                datetime.date(2020, 1, 1),
+                datetime.date(2020, 1, 2),
+                datetime.date(2020, 1, 3),
+                datetime.date(2020, 1, 4),
+            ],
+            "Close": [100.0, 110.0, 121.0, 133.1],
+        }
+    )
+    strategy = MockHoldingStrategy({"signals": [0.0, 1.0, 1.0, 0.0]})
+    backtester = Backtester(data, strategy, transaction_cost_bps=10.0, slippage_bps=5.0)
+    results = backtester.run()
+
+    ledger = build_trade_ledger(results)
+
+    assert ledger["Action"].to_list() == ["Enter Long", "Exit Long"]
+    assert ledger["Reason"].to_list() == [
+        "Strategy signal changed",
+        "Strategy signal changed",
+    ]
+    assert ledger["Transaction Costs"].to_list() == pytest.approx([0.0015, 0.0015])
+    assert ledger["Holding Period Days"].to_list() == [None, 2]
+
+
+def test_trade_ledger_normalises_datetime_dates():
+    """
+    Verify that live datetime dates can be rendered in the trade ledger.
+    """
+    data = pl.DataFrame(
+        {
+            "Date": [
+                datetime.datetime(2020, 1, 1),
+                datetime.datetime(2020, 1, 2),
+                datetime.datetime(2020, 1, 3),
+            ],
+            "Close": [100.0, 110.0, 121.0],
+        }
+    )
+    strategy = MockHoldingStrategy({"signals": [0.0, 1.0, 0.0]})
+    backtester = Backtester(data, strategy)
+    results = backtester.run()
+
+    ledger = build_trade_ledger(results)
+
+    assert ledger["Date"].dtype == pl.Date
+    assert ledger["Date"].to_list() == [
+        datetime.date(2020, 1, 2),
+        datetime.date(2020, 1, 3),
+    ]
+
+
+def test_trade_ledger_records_pair_rebalances():
+    """
+    Verify that pair leg-weight changes are visible even without signal changes.
+    """
+    data = pl.DataFrame(
+        {
+            "Date": [
+                datetime.date(2020, 1, 1),
+                datetime.date(2020, 1, 2),
+                datetime.date(2020, 1, 3),
+            ],
+            "Close_1": [100.0, 100.0, 100.0],
+            "Close_2": [100.0, 100.0, 100.0],
+        }
+    )
+    strategy = MockPairsWeightedStrategy(
+        {
+            "signals": [0.0, 1.0, 1.0],
+            "leg_1_weights": [0.0, 0.5, 1 / 3],
+            "leg_2_weights": [0.0, -0.5, -2 / 3],
+        }
+    )
+    backtester = Backtester(data, strategy, transaction_cost_bps=10.0, slippage_bps=5.0)
+    results = backtester.run()
+
+    ledger = build_trade_ledger(results)
+
+    assert ledger["Action"].to_list() == ["Enter Long", "Rebalance"]
+    assert ledger["Reason"].to_list() == [
+        "Strategy signal changed",
+        "Leg weights changed",
+    ]
+    assert ledger["Turnover"].to_list() == pytest.approx([1.0, 1 / 3])
+    assert ledger["Leg 1 Weight"].to_list() == pytest.approx([0.5, 1 / 3])
+    assert ledger["Leg 2 Weight"].to_list() == pytest.approx([-0.5, -2 / 3])

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -3,12 +3,14 @@ Contains tests for optimisation functions.
 """
 
 import datetime
+import math
 from typing import Any
 
 import polars as pl
 import pytest
 from quant_trading_strategy_backtester.app import (
     _get_final_backtest_data,
+    _get_final_backtest_results,
     prepare_buy_and_hold_strategy_with_optimisation,
     prepare_pairs_trading_strategy_with_optimisation,
     prepare_single_ticker_strategy_with_optimisation,
@@ -886,6 +888,49 @@ def test_get_final_backtest_data_uses_validation_split():
     assert len(full_data) == 100
 
 
+def test_get_final_backtest_results_preserves_context_and_resets_returns():
+    """Verify validation display uses contextual results but validation returns."""
+    dates = [datetime.date(2020, 1, 1) + datetime.timedelta(days=i) for i in range(10)]
+    context_results = pl.DataFrame(
+        {
+            "Date": dates,
+            "signal": [0.0, 0.0, 1.0, 1.0, 1.0, 0.0, -1.0, -1.0, 0.0, 0.0],
+            "position_change": [0.0, 0.0, 1.0, 0.0, 0.0, -1.0, -1.0, 0.0, 1.0, 0.0],
+            "gross_strategy_returns": [0.1] * 10,
+            "transaction_costs": [0.01] * 10,
+            "strategy_returns": [0.09] * 10,
+            "trade_turnover": [0.0] * 10,
+            "cumulative_transaction_costs": [0.01 * (i + 1) for i in range(10)],
+            "gross_cumulative_returns": [99.0] * 10,
+            "cumulative_returns": [99.0] * 10,
+            "equity_curve": [9_999_999.0] * 10,
+        }
+    )
+    validation_data = pl.DataFrame({"Date": dates[7:]})
+
+    final_results = _get_final_backtest_results(
+        context_results,
+        validation_data,
+        use_validation_data=True,
+        initial_capital=100_000.0,
+    )
+
+    assert final_results["Date"].to_list() == dates[7:]
+    assert final_results["signal"].to_list() == [-1.0, 0.0, 0.0]
+    assert final_results["cumulative_returns"].to_list() == pytest.approx(
+        [1.09, 1.1881, 1.295029]
+    )
+    assert final_results["gross_cumulative_returns"].to_list() == pytest.approx(
+        [1.1, 1.21, 1.331]
+    )
+    assert final_results["cumulative_transaction_costs"].to_list() == pytest.approx(
+        [0.01, 0.02, 0.03]
+    )
+    assert final_results["equity_curve"].to_list() == pytest.approx(
+        [109_000.0, 118_810.0, 129_502.9]
+    )
+
+
 def test_optimise_strategy_params_returns_test_metrics(monkeypatch):
     """Verify optimise_strategy_params evaluates best params on test data."""
     train_data = pl.DataFrame(
@@ -938,6 +983,68 @@ def test_optimise_strategy_params_returns_test_metrics(monkeypatch):
     # Metrics should be from test data
     assert metrics["Sharpe Ratio"] == 0.5
     assert metrics["Total Return"] == 0.05
+
+
+def test_optimise_strategy_params_skips_nan_sharpe(monkeypatch):
+    """Verify optimisation ignores parameter sets with undefined Sharpe."""
+    data = pl.DataFrame(
+        {
+            "Date": [datetime.date(2020, 1, i) for i in range(1, 22)],
+            "Close": [100 + i for i in range(21)],
+        }
+    )
+
+    def mock_run_backtest(data, strategy_type, params, tickers):
+        sharpe = math.nan if params["short_window"] == 5 else 1.0
+        return None, {
+            "Sharpe Ratio": sharpe,
+            "Total Return": 0.1,
+            "Max Drawdown": -0.05,
+        }
+
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.run_backtest", mock_run_backtest
+    )
+
+    params, metrics = optimise_strategy_params(
+        data,
+        "Moving Average Crossover",
+        {"short_window": [5, 10], "long_window": [20]},
+        "AAPL",
+    )
+
+    assert params == {"short_window": 10, "long_window": 20}
+    assert metrics["Sharpe Ratio"] == 1.0
+
+
+def test_optimise_strategy_params_raises_when_all_sharpes_are_nan(monkeypatch):
+    """Verify optimisation fails clearly when every candidate is untradeable."""
+    data = pl.DataFrame(
+        {
+            "Date": [datetime.date(2020, 1, i) for i in range(1, 22)],
+            "Close": [100 + i for i in range(21)],
+        }
+    )
+
+    def mock_run_backtest(data, strategy_type, params, tickers):
+        return None, {
+            "Sharpe Ratio": math.nan,
+            "Total Return": 0.0,
+            "Max Drawdown": 0.0,
+            "Trade Events": 0.0,
+        }
+
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.run_backtest", mock_run_backtest
+    )
+
+    with pytest.raises(ValueError, match="Parameter optimisation failed"):
+        optimise_strategy_params(
+            data,
+            "Moving Average Crossover",
+            {"short_window": [5, 10], "long_window": [20]},
+            "AAPL",
+        )
 
 
 def test_optimise_strategy_params_skips_invalid_parameter_combinations(


### PR DESCRIPTION
# Summary
- Added return-level cost attribution across backtests
  - Gross returns, net returns, turnover, cumulative costs, and cost drag now stay visible alongside existing performance metrics
- Added a trade ledger for exposure-changing events
  - Single-asset entries, exits, and pairs leg rebalances are surfaced without inventing broker-level fills the engine does not model
- Fixed optimised validation display for rolling strategies
  - Final validation results now keep historical context for rolling indicators while resetting displayed returns, costs, and equity over the held-out rows
- Hardened optimiser scoring against undefined candidates
  - Non-finite optimisation scores are skipped instead of being treated as viable winners
- Updated the Streamlit results view and regression coverage
  - Undefined metrics render as `N/A`, and no-trade validation periods are called out explicitly

## Related Issues
Fixes #47

## Rationale
- The current engine models target exposures rather than executable orders
  - A return-level ledger keeps the attribution honest while avoiding fake share quantities, fill prices, or cash balances
- Rolling pairs strategies need historical context at validation boundaries
  - Cold-starting a 90-day hedge-ratio/z-score window on only the held-out slice can erase valid out-of-sample trades and display a misleading `nan` Sharpe
- Pairs trading costs need turnover based on leg-weight changes rather than only signal changes
  - Hedge-ratio-driven rebalances can create real cost drag even when the spread direction remains unchanged

## Manual Test Evidence
- Browser-smoked the local Streamlit app on `127.0.0.1:8501`
  - Buy and Hold rendered Cost Attribution and Trade Ledger with no traceback
  - Pairs Trading rendered pair results, spread chart, Cost Attribution, and Trade Ledger with no traceback
- Reproduced the AVGO/JPM optimised-parameter validation case locally
  - The held-out result moved from zero trades and `nan` Sharpe to 22 trade events and finite validation metrics when rolling context was preserved
