### PR TITLE
feat: Add cointegration filter for pairs selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ _Try the deployed app
   for realistic performance estimates
 - **Trade ledger and cost attribution** – explicit trade events, turnover,
   gross/net returns, and cumulative cost drag
+- **Cointegration-gated pairs selection** – Engle-Granger filtering for
+  automatic pairs trading selection and p-value diagnostics for manual pairs
 - **Efficient data processing** – vectorised computation using Polars for
   improved performance
 - **Interactive web-based dashboard** – Streamlit UI for strategy configuration,
@@ -38,7 +40,8 @@ _Try the deployed app
 
 - **Pairs trading** uses a rolling hedge ratio to build the spread and
   exposure-normalised leg weights to calculate pair returns and transaction
-  costs
+  costs. Automatic pair selection first filters candidates using an
+  Engle-Granger cointegration test on the training split
 - **Ticker/pair selection** uses a 70/30 train/test split – tickers are
   selected on training data and evaluated on held-out test data to reduce
   look-ahead bias

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "sqlalchemy<3.0.0,>=2.0.35",
     "lxml>=5.4.0",
     "requests>=2.32.5",
+    "statsmodels>=0.14.5,<1.0",
 ]
 
 [build-system]

--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -18,6 +18,7 @@ import polars as pl
 import streamlit as st
 
 from quant_trading_strategy_backtester.backtester import Backtester, is_running_locally
+from quant_trading_strategy_backtester.cointegration import evaluate_cointegration
 from quant_trading_strategy_backtester.data import (
     get_full_company_name,
     get_top_sp500_companies,
@@ -27,6 +28,7 @@ from quant_trading_strategy_backtester.data import (
 from quant_trading_strategy_backtester.models import Session, StrategyModel
 from quant_trading_strategy_backtester.optimiser import (
     create_strategy,
+    get_training_data,
     get_validation_data,
     optimise_buy_and_hold_ticker,
     optimise_pairs_trading_tickers,
@@ -163,6 +165,39 @@ def _get_performance_metrics_for_results(
     )
 
     return metrics
+
+
+def _display_cointegration_result(data: pl.DataFrame, context: str) -> None:
+    """
+    Display an Engle-Granger cointegration diagnostic for a selected pair.
+
+    Args:
+        data: Pair price data to test.
+        context: Description of the data period being tested.
+    """
+    result = evaluate_cointegration(data)
+    if result.is_cointegrated:
+        st.success(
+            "Cointegration filter passed "
+            f"({context}; Engle-Granger p-value: {result.p_value:.4f})."
+        )
+        return
+
+    reason = f" {result.reason}." if result.reason else ""
+    st.warning(
+        "Cointegration filter failed "
+        f"({context}; Engle-Granger p-value: {_format_p_value(result.p_value)})."
+        f"{reason} Manual pairs are still allowed, but the relationship may "
+        "not be mean-reverting."
+    )
+
+
+def _format_p_value(value: float) -> str:
+    """Format p-values for Streamlit diagnostics."""
+    if value != value:
+        return "N/A"
+
+    return f"{value:.4f}"
 
 
 # Trading strategy preparation functions
@@ -359,6 +394,10 @@ def prepare_pairs_trading_strategy_with_optimisation(
     # Load historical data for the selected pair.
     data = load_yfinance_data_two_tickers(ticker1, ticker2, start_date, end_date)
     ticker_display = f"{ticker1} vs. {ticker2}"
+    _display_cointegration_result(
+        get_training_data(data),
+        "training split used for pair selection",
+    )
 
     if optimise and walk_forward:
         strategy_params, _ = run_optimisation(
@@ -429,6 +468,7 @@ def prepare_pairs_trading_strategy_without_optimisation(
     ticker1, ticker2 = ticker
     data = load_yfinance_data_two_tickers(ticker1, ticker2, start_date, end_date)
     ticker_display = f"{ticker1} vs. {ticker2}"
+    _display_cointegration_result(data, "selected date range")
 
     if optimise:
         strategy_params, _ = run_optimisation(

--- a/src/quant_trading_strategy_backtester/cointegration.py
+++ b/src/quant_trading_strategy_backtester/cointegration.py
@@ -1,0 +1,96 @@
+"""
+Evaluate pair cointegration for pairs-trading selection and diagnostics.
+"""
+
+from dataclasses import dataclass
+import math
+
+import numpy as np
+import polars as pl
+from statsmodels.tsa.stattools import coint
+
+COINTEGRATION_P_VALUE_THRESHOLD = 0.05
+MIN_COINTEGRATION_OBSERVATIONS = 30
+
+
+@dataclass(frozen=True)
+class CointegrationResult:
+    """Store the outcome of an Engle-Granger cointegration test."""
+
+    is_cointegrated: bool
+    p_value: float
+    test_statistic: float
+    critical_value_1pct: float
+    critical_value_5pct: float
+    critical_value_10pct: float
+    reason: str | None = None
+
+
+def evaluate_cointegration(
+    data: pl.DataFrame,
+    p_value_threshold: float = COINTEGRATION_P_VALUE_THRESHOLD,
+) -> CointegrationResult:
+    """
+    Run an Engle-Granger cointegration test on a candidate pair.
+
+    Args:
+        data: Pair price data containing Close_1 and Close_2.
+        p_value_threshold: Maximum p-value accepted as cointegrated.
+
+    Returns:
+        A cointegration test result with p-value and critical values.
+
+    Raises:
+        ValueError: If required price columns are missing.
+    """
+    if "Close_1" not in data.columns or "Close_2" not in data.columns:
+        raise ValueError("Cointegration test requires Close_1 and Close_2 columns")
+
+    cleaned_data = data.select(["Close_1", "Close_2"]).drop_nulls()
+    if cleaned_data.height < MIN_COINTEGRATION_OBSERVATIONS:
+        return _failed_result("Not enough observations for cointegration test")
+
+    close_1 = cleaned_data["Close_1"].cast(pl.Float64).to_numpy()
+    close_2 = cleaned_data["Close_2"].cast(pl.Float64).to_numpy()
+    if not bool(np.isfinite(close_1).all() and np.isfinite(close_2).all()):
+        return _failed_result("Price series contains non-finite values")
+    if np.isclose(float(np.std(close_1)), 0.0) or np.isclose(
+        float(np.std(close_2)), 0.0
+    ):
+        return _failed_result("Price series is constant")
+
+    try:
+        test_statistic, p_value, critical_values = coint(
+            close_1,
+            close_2,
+            trend="c",
+            autolag="aic",
+        )
+    except (ValueError, np.linalg.LinAlgError) as exc:
+        return _failed_result(f"Cointegration test failed: {exc}")
+
+    p_value = float(p_value)
+    if not math.isfinite(p_value):
+        return _failed_result("Cointegration test returned a non-finite p-value")
+
+    return CointegrationResult(
+        is_cointegrated=p_value <= p_value_threshold,
+        p_value=p_value,
+        test_statistic=float(test_statistic),
+        critical_value_1pct=float(critical_values[0]),
+        critical_value_5pct=float(critical_values[1]),
+        critical_value_10pct=float(critical_values[2]),
+    )
+
+
+def _failed_result(reason: str) -> CointegrationResult:
+    """Return a failed cointegration result with undefined statistics."""
+    return CointegrationResult(
+        is_cointegrated=False,
+        p_value=float("nan"),
+        test_statistic=float("nan"),
+        critical_value_1pct=float("nan"),
+        critical_value_5pct=float("nan"),
+        critical_value_10pct=float("nan"),
+        reason=reason,
+    )

--- a/src/quant_trading_strategy_backtester/optimiser.py
+++ b/src/quant_trading_strategy_backtester/optimiser.py
@@ -13,6 +13,10 @@ import polars as pl
 import streamlit as st
 
 from quant_trading_strategy_backtester.backtester import Backtester
+from quant_trading_strategy_backtester.cointegration import (
+    COINTEGRATION_P_VALUE_THRESHOLD,
+    evaluate_cointegration,
+)
 from quant_trading_strategy_backtester.data import (
     get_top_sp500_companies,
     is_same_company,
@@ -85,6 +89,34 @@ def get_validation_data(
 
     _, test_data = _split_data(data)
     return test_data
+
+
+def get_training_data(
+    data: pl.DataFrame, walk_forward: bool = False, n_folds: int = WALK_FORWARD_FOLDS
+) -> pl.DataFrame:
+    """
+    Return the training data used for ticker or parameter optimisation.
+
+    Args:
+        data: Historical price data.
+        walk_forward: Whether the optimisation used walk-forward validation.
+        n_folds: Number of walk-forward test folds.
+
+    Returns:
+        The standard training split, or the final walk-forward training
+        context.
+    """
+    if walk_forward:
+        segment_size = len(data) // (n_folds + 1)
+        if segment_size < 2:
+            raise ValueError(
+                f"Not enough data for {n_folds} folds: "
+                f"{len(data)} rows, need at least {2 * (n_folds + 1)}"
+            )
+        return data[: segment_size * n_folds]
+
+    train_data, _ = _split_data(data)
+    return train_data
 
 
 def _optimisation_score(
@@ -389,6 +421,7 @@ def optimise_pairs_trading_tickers(
     end_date: datetime.date,
     strategy_params: dict[str, Any],
     optimise: bool,
+    cointegration_p_value_threshold: float = COINTEGRATION_P_VALUE_THRESHOLD,
 ) -> tuple[tuple[str, str], dict[str, Any], dict[str, float]]:
     """
     Optimises ticker pair selection and strategy parameters for pairs trading.
@@ -404,6 +437,8 @@ def optimise_pairs_trading_tickers(
         end_date: End date for historical data.
         strategy_params: Strategy parameters or parameter ranges.
         optimise: Whether to optimise the strategy parameters.
+        cointegration_p_value_threshold: Maximum Engle-Granger p-value
+            accepted for automatic pair selection.
 
     Returns:
         A tuple containing the best ticker pair, best parameters, and best
@@ -426,6 +461,7 @@ def optimise_pairs_trading_tickers(
     progress_bar = st.progress(0)
     status_text = st.empty()
     prev_pair_processing_time = 0.0
+    rejected_pairs = 0
 
     for i, (ticker1, ticker2) in enumerate(ticker_pairs):
         start_time = time.time()
@@ -440,6 +476,15 @@ def optimise_pairs_trading_tickers(
             continue
 
         train_data, test_data = _split_data(data)
+        cointegration_result = evaluate_cointegration(
+            train_data,
+            p_value_threshold=cointegration_p_value_threshold,
+        )
+        if not cointegration_result.is_cointegrated:
+            rejected_pairs += 1
+            end_time = time.time()
+            prev_pair_processing_time = end_time - start_time
+            continue
 
         if optimise:
             # Convert single values to lists for optimisation
@@ -472,7 +517,11 @@ def optimise_pairs_trading_tickers(
     progress_bar.empty()
     status_text.empty()
     if not best_pair or not best_params or best_test_data is None:
-        raise ValueError("Pairs trading optimisation failed")
+        raise ValueError(
+            "Pairs trading optimisation failed: no cointegrated pair produced "
+            f"a finite Sharpe ratio ({rejected_pairs} pairs rejected by "
+            "cointegration filter)"
+        )
 
     _, best_metrics = run_backtest(
         best_test_data, "Pairs Trading", best_params, list(best_pair)

--- a/tests/test_cointegration.py
+++ b/tests/test_cointegration.py
@@ -1,0 +1,54 @@
+"""
+Tests for pair cointegration diagnostics.
+"""
+
+import numpy as np
+import polars as pl
+import pytest
+
+from quant_trading_strategy_backtester.cointegration import evaluate_cointegration
+
+
+def test_cointegration_accepts_stationary_linear_relationship() -> None:
+    """Verify Engle-Granger accepts a stationary pair relationship."""
+    rng = np.random.default_rng(42)
+    close_2 = np.cumsum(rng.normal(0, 1, 300)) + 100
+    close_1 = 5 + 2 * close_2 + rng.normal(0, 0.5, 300)
+    data = pl.DataFrame({"Close_1": close_1, "Close_2": close_2})
+
+    result = evaluate_cointegration(data)
+
+    assert result.is_cointegrated
+    assert result.p_value < 0.05
+    assert result.reason is None
+
+
+def test_cointegration_rejects_independent_random_walks() -> None:
+    """Verify Engle-Granger rejects unrelated random walks."""
+    rng = np.random.default_rng(12)
+    close_1 = np.cumsum(rng.normal(0, 1, 300)) + 100
+    close_2 = np.cumsum(rng.normal(0, 1, 300)) + 50
+    data = pl.DataFrame({"Close_1": close_1, "Close_2": close_2})
+
+    result = evaluate_cointegration(data)
+
+    assert not result.is_cointegrated
+    assert result.p_value > 0.05
+
+
+def test_cointegration_rejects_short_series() -> None:
+    """Verify short samples are rejected rather than force-ranked."""
+    data = pl.DataFrame({"Close_1": [1.0, 2.0], "Close_2": [2.0, 3.0]})
+
+    result = evaluate_cointegration(data)
+
+    assert not result.is_cointegrated
+    assert result.reason == "Not enough observations for cointegration test"
+
+
+def test_cointegration_requires_pair_close_columns() -> None:
+    """Verify missing pair columns fail clearly."""
+    data = pl.DataFrame({"Close": [1.0, 2.0, 3.0]})
+
+    with pytest.raises(ValueError, match="Close_1 and Close_2"):
+        evaluate_cointegration(data)

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -15,6 +15,7 @@ from quant_trading_strategy_backtester.app import (
     prepare_pairs_trading_strategy_with_optimisation,
     prepare_single_ticker_strategy_with_optimisation,
 )
+from quant_trading_strategy_backtester.cointegration import CointegrationResult
 from quant_trading_strategy_backtester.optimiser import (
     _split_data,
     get_validation_data,
@@ -26,6 +27,19 @@ from quant_trading_strategy_backtester.optimiser import (
     run_optimisation,
     walk_forward_optimise,
 )
+
+
+def _cointegration_result(is_cointegrated: bool) -> CointegrationResult:
+    """Return a deterministic cointegration result for optimiser tests."""
+    return CointegrationResult(
+        is_cointegrated=is_cointegrated,
+        p_value=0.01 if is_cointegrated else 0.5,
+        test_statistic=-4.0 if is_cointegrated else -1.0,
+        critical_value_1pct=-3.9,
+        critical_value_5pct=-3.3,
+        critical_value_10pct=-3.0,
+        reason=None if is_cointegrated else "Pair is not cointegrated",
+    )
 
 
 def test_optimise_buy_and_hold_ticker(monkeypatch):
@@ -201,6 +215,10 @@ def test_optimise_pairs_trading_tickers(monkeypatch):
         "quant_trading_strategy_backtester.optimiser.optimise_strategy_params",
         mock_optimise_strategy_params,
     )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.evaluate_cointegration",
+        lambda *_args, **_kwargs: _cointegration_result(True),
+    )
 
     start_date = datetime.date(2020, 1, 1)
     end_date = datetime.date(2020, 12, 31)
@@ -279,6 +297,10 @@ def test_optimise_pairs_trading_tickers_ranks_fixed_pairs_on_train(monkeypatch):
     )
     monkeypatch.setattr(
         "quant_trading_strategy_backtester.optimiser.run_backtest", mock_run_backtest
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.evaluate_cointegration",
+        lambda *_args, **_kwargs: _cointegration_result(True),
     )
 
     best_pair, best_params, metrics = optimise_pairs_trading_tickers(
@@ -363,6 +385,10 @@ def test_optimise_pairs_trading_tickers_ranks_optimised_pairs_on_train(
     )
     monkeypatch.setattr(
         "quant_trading_strategy_backtester.optimiser.run_backtest", mock_run_backtest
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.evaluate_cointegration",
+        lambda *_args, **_kwargs: _cointegration_result(True),
     )
 
     best_pair, best_params, metrics = optimise_pairs_trading_tickers(

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -18,6 +18,7 @@ from quant_trading_strategy_backtester.app import (
 from quant_trading_strategy_backtester.cointegration import CointegrationResult
 from quant_trading_strategy_backtester.optimiser import (
     _split_data,
+    get_training_data,
     get_validation_data,
     optimise_buy_and_hold_ticker,
     optimise_pairs_trading_tickers,
@@ -406,6 +407,111 @@ def test_optimise_pairs_trading_tickers_ranks_optimised_pairs_on_train(
         "exit_z_score": 0.5,
     }
     assert metrics["Sharpe Ratio"] == -1.0
+
+
+def test_optimise_pairs_trading_tickers_filters_non_cointegrated_pairs(
+    monkeypatch,
+) -> None:
+    """Verify automatic pair selection rejects non-cointegrated candidates."""
+    mock_top_companies = [("AAPL", 1000000.0), ("GOOGL", 900000.0), ("MSFT", 800000.0)]
+    dates = [datetime.date(2020, 1, 1) + datetime.timedelta(days=i) for i in range(100)]
+    base_data = pl.DataFrame(
+        {
+            "Date": dates,
+            "Close_1": [100.0 + i * 0.1 for i in range(100)],
+            "Close_2": [200.0 + i * 0.2 for i in range(100)],
+        }
+    )
+    strategy_params = {"window": 20, "entry_z_score": 2.0, "exit_z_score": 0.5}
+    train_scores = {
+        ("AAPL", "GOOGL"): 99.0,
+        ("AAPL", "MSFT"): 2.0,
+        ("GOOGL", "MSFT"): 1.0,
+    }
+
+    def mock_load_data(ticker1, ticker2, *_args, **_kwargs):
+        return base_data.with_columns(pl.lit(f"{ticker1}/{ticker2}").alias("Pair"))
+
+    def mock_evaluate_cointegration(data, **_kwargs):
+        pair = tuple(data["Pair"][0].split("/"))
+        return _cointegration_result(pair != ("AAPL", "GOOGL"))
+
+    def mock_run_backtest(data, strategy_type, params, tickers):
+        pair = tuple(tickers)
+        return None, {
+            "Sharpe Ratio": train_scores[pair],
+            "Total Return": 0.1,
+            "Max Drawdown": -0.05,
+        }
+
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.load_yfinance_data_two_tickers",
+        mock_load_data,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.is_same_company",
+        lambda *_args: False,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.evaluate_cointegration",
+        mock_evaluate_cointegration,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.run_backtest", mock_run_backtest
+    )
+
+    best_pair, _, metrics = optimise_pairs_trading_tickers(
+        mock_top_companies,
+        datetime.date(2020, 1, 1),
+        datetime.date(2020, 12, 31),
+        strategy_params,
+        optimise=False,
+    )
+
+    assert best_pair == ("AAPL", "MSFT")
+    assert metrics["Sharpe Ratio"] == 2.0
+
+
+def test_optimise_pairs_trading_tickers_raises_when_all_pairs_fail_filter(
+    monkeypatch,
+) -> None:
+    """Verify pair selection fails clearly when no candidate is cointegrated."""
+    mock_top_companies = [("AAPL", 1000000.0), ("GOOGL", 900000.0)]
+    dates = [datetime.date(2020, 1, 1) + datetime.timedelta(days=i) for i in range(100)]
+    mock_polars_data = pl.DataFrame(
+        {
+            "Date": dates,
+            "Close_1": [100.0 + i * 0.1 for i in range(100)],
+            "Close_2": [200.0 + i * 0.2 for i in range(100)],
+        }
+    )
+    strategy_params = {"window": 20, "entry_z_score": 2.0, "exit_z_score": 0.5}
+
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.load_yfinance_data_two_tickers",
+        lambda *_args, **_kwargs: mock_polars_data,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.is_same_company",
+        lambda *_args: False,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.evaluate_cointegration",
+        lambda *_args, **_kwargs: _cointegration_result(False),
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.run_backtest",
+        lambda *_args, **_kwargs: pytest.fail("Backtest should not run"),
+    )
+
+    with pytest.raises(ValueError, match="no cointegrated pair"):
+        optimise_pairs_trading_tickers(
+            mock_top_companies,
+            datetime.date(2020, 1, 1),
+            datetime.date(2020, 12, 31),
+            strategy_params,
+            optimise=False,
+        )
 
 
 def test_handle_pairs_trading_optimisation(monkeypatch):
@@ -897,6 +1003,24 @@ def test_get_validation_data_walk_forward():
     assert len(validation_data) == 10
     assert validation_data["Close"][0] == 50
     assert validation_data["Close"][-1] == 59
+
+
+def test_get_training_data_standard_split():
+    """Verify standard optimisation training uses the 70% train split."""
+    data = pl.DataFrame({"Close": list(range(100))})
+    training_data = get_training_data(data)
+    assert len(training_data) == 70
+    assert training_data["Close"][0] == 0
+    assert training_data["Close"][-1] == 69
+
+
+def test_get_training_data_walk_forward():
+    """Verify walk-forward training uses the expanding context before final fold."""
+    data = pl.DataFrame({"Close": list(range(60))})
+    training_data = get_training_data(data, walk_forward=True, n_folds=5)
+    assert len(training_data) == 50
+    assert training_data["Close"][0] == 0
+    assert training_data["Close"][-1] == 49
 
 
 def test_get_final_backtest_data_uses_validation_split():

--- a/uv.lock
+++ b/uv.lock
@@ -501,6 +501,18 @@ wheels = [
 ]
 
 [[package]]
+name = "patsy"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/44/ed13eccdd0519eff265f44b670d46fbb0ec813e2274932dc1c0e48520f7d/patsy-1.0.2.tar.gz", hash = "sha256:cdc995455f6233e90e22de72c37fcadb344e7586fb83f06696f54d92f8ce74c0", size = 399942, upload-time = "2025-10-20T16:17:37.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/70/ba4b949bdc0490ab78d545459acd7702b211dfccf7eb89bbc1060f52818d/patsy-1.0.2-py2.py3-none-any.whl", hash = "sha256:37bfddbc58fcf0362febb5f54f10743f8b21dd2aa73dec7e7ef59d1b02ae668a", size = 233301, upload-time = "2025-10-20T16:17:36.563Z" },
+]
+
+[[package]]
 name = "peewee"
 version = "3.19.0"
 source = { registry = "https://pypi.org/simple" }
@@ -771,6 +783,7 @@ dependencies = [
     { name = "polars" },
     { name = "requests" },
     { name = "sqlalchemy" },
+    { name = "statsmodels" },
     { name = "streamlit" },
     { name = "yfinance" },
 ]
@@ -796,6 +809,7 @@ requires-dist = [
     { name = "polars", specifier = ">=1.37.1,<2.0" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "sqlalchemy", specifier = ">=2.0.35,<3.0.0" },
+    { name = "statsmodels", specifier = ">=0.14.5,<1.0" },
     { name = "streamlit", specifier = ">=1.53.0,<2.0" },
     { name = "yfinance", specifier = ">=1.0" },
 ]
@@ -904,6 +918,37 @@ wheels = [
 ]
 
 [[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -961,6 +1006,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
+]
+
+[[package]]
+name = "statsmodels"
+version = "0.14.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "patsy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/81/e8d74b34f85285f7335d30c5e3c2d7c0346997af9f3debf9a0a9a63de184/statsmodels-0.14.6.tar.gz", hash = "sha256:4d17873d3e607d398b85126cd4ed7aad89e4e9d89fc744cdab1af3189a996c2a", size = 20689085, upload-time = "2025-12-05T23:08:39.522Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/59/a5aad5b0cc266f5be013db8cde563ac5d2a025e7efc0c328d83b50c72992/statsmodels-0.14.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47ee7af083623d2091954fa71c7549b8443168f41b7c5dce66510274c50fd73e", size = 10072009, upload-time = "2025-12-05T23:11:14.021Z" },
+    { url = "https://files.pythonhosted.org/packages/53/dd/d8cfa7922fc6dc3c56fa6c59b348ea7de829a94cd73208c6f8202dd33f17/statsmodels-0.14.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:aa60d82e29fcd0a736e86feb63a11d2380322d77a9369a54be8b0965a3985f71", size = 9980018, upload-time = "2025-12-05T23:11:30.907Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/77/0ec96803eba444efd75dba32f2ef88765ae3e8f567d276805391ec2c98c6/statsmodels-0.14.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:89ee7d595f5939cc20bf946faedcb5137d975f03ae080f300ebb4398f16a5bd4", size = 10060269, upload-time = "2025-12-05T23:11:46.338Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b9/fd41f1f6af13a1a1212a06bb377b17762feaa6d656947bf666f76300fc05/statsmodels-0.14.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:730f3297b26749b216a06e4327fe0be59b8d05f7d594fb6caff4287b69654589", size = 10324155, upload-time = "2025-12-05T23:12:01.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/0f/a6900e220abd2c69cd0a07e3ad26c71984be6061415a60e0f17b152ecf08/statsmodels-0.14.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f1c08befa85e93acc992b72a390ddb7bd876190f1360e61d10cf43833463bc9c", size = 10349765, upload-time = "2025-12-05T23:12:18.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/08/b79f0c614f38e566eebbdcff90c0bcacf3c6ba7a5bbb12183c09c29ca400/statsmodels-0.14.6-cp313-cp313-win_amd64.whl", hash = "sha256:8021271a79f35b842c02a1794465a651a9d06ec2080f76ebc3b7adce77d08233", size = 9540043, upload-time = "2025-12-05T23:12:33.887Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary
- Added a cointegration gate for automatic pairs selection
  - Candidate pairs were tested on the training split before Sharpe ranking
  - Non-cointegrated or statistically invalid pairs were rejected instead of being eligible as optimal
- Added dashboard diagnostics for selected pairs
  - Manual pair selections now show the Engle-Granger p-value and remain runnable with a warning when the relationship is not mean-reverting
- Updated the pairs methodology and dependency set for the new statistical filter
- Expanded regression coverage around cointegration acceptance, rejection, and optimiser ranking behaviour

## Rationale
- A high Sharpe from a non-cointegrated spread is not a valid pairs-trading selection signal – filtering before ranking prevents the optimiser from treating an unrelated pair as optimal
- The filter runs on the same training split used for pair selection – this keeps the held-out period out of the selection decision

## Manual Test Evidence
- Opened the Streamlit app locally, switched from Buy and Hold to Pairs Trading, and confirmed the default AAPL/GOOGL manual pair rendered a cointegration warning with p-value `0.6074`, the pairs results headings and spread chart loaded, and no traceback appeared
