### PR TITLE
feat: Add benchmark-relative reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ _Try the deployed app
   gross/net returns, and cumulative cost drag
 - **Cointegration-gated pairs selection** – Engle-Granger filtering for
   automatic pairs trading selection and p-value diagnostics for manual pairs
+- **Benchmark-relative reporting** – SPY-relative excess return, beta,
+  annualised alpha, and information ratio for the displayed backtest period
 - **Efficient data processing** – vectorised computation using Polars for
   improved performance
 - **Interactive web-based dashboard** – Streamlit UI for strategy configuration,
@@ -45,6 +47,8 @@ _Try the deployed app
 - **Ticker/pair selection** uses a 70/30 train/test split – tickers are
   selected on training data and evaluated on held-out test data to reduce
   look-ahead bias
+- **Benchmark comparison** aligns the strategy and SPY return streams by date
+  over the displayed backtest period before calculating relative metrics
 - **Walk-forward validation** uses expanding training windows for more
   robust out-of-sample evaluation – recommended over the default split
 - **Survivorship bias** remains a limitation – automatic ticker selection uses

--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -18,6 +18,10 @@ import polars as pl
 import streamlit as st
 
 from quant_trading_strategy_backtester.backtester import Backtester, is_running_locally
+from quant_trading_strategy_backtester.benchmark import (
+    BENCHMARK_TICKER,
+    calculate_benchmark_relative_metrics,
+)
 from quant_trading_strategy_backtester.cointegration import evaluate_cointegration
 from quant_trading_strategy_backtester.data import (
     get_full_company_name,
@@ -45,6 +49,7 @@ from quant_trading_strategy_backtester.utils import (
     NUM_TOP_COMPANIES_TWO_TICKERS,
 )
 from quant_trading_strategy_backtester.visualisation import (
+    display_benchmark_metrics,
     display_performance_metrics,
     display_returns_by_month,
     display_trade_ledger,
@@ -198,6 +203,69 @@ def _format_p_value(value: float) -> str:
         return "N/A"
 
     return f"{value:.4f}"
+
+
+def _get_benchmark_date_range(
+    data: pl.DataFrame,
+) -> tuple[datetime.date, datetime.date]:
+    """
+    Return the inclusive start and exclusive end dates for benchmark loading.
+
+    Args:
+        data: Backtest data containing a Date column.
+
+    Returns:
+        A start date and Yahoo-compatible exclusive end date.
+    """
+    start_date = _to_date(data["Date"].min())
+    end_date = _to_date(data["Date"].max()) + datetime.timedelta(days=1)
+    return start_date, end_date
+
+
+def _to_date(value: Any) -> datetime.date:
+    """Convert Polars scalar date values to Python dates."""
+    if isinstance(value, datetime.datetime):
+        return value.date()
+    if isinstance(value, datetime.date):
+        return value
+    if hasattr(value, "date"):
+        date_value = value.date()
+        if isinstance(date_value, datetime.date):
+            return date_value
+
+    raise TypeError(f"Expected date-like value, got {type(value).__name__}")
+
+
+def _display_benchmark_comparison(
+    results: pl.DataFrame, backtest_data: pl.DataFrame
+) -> None:
+    """
+    Display strategy metrics relative to the default benchmark.
+
+    Args:
+        results: Backtest results for the displayed period.
+        backtest_data: Price data for the displayed period.
+    """
+    try:
+        benchmark_start_date, benchmark_end_date = _get_benchmark_date_range(
+            backtest_data
+        )
+        benchmark_data = load_yfinance_data_one_ticker(
+            BENCHMARK_TICKER, benchmark_start_date, benchmark_end_date
+        )
+    except Exception as exc:
+        st.warning(f"Benchmark comparison unavailable: {exc}")
+        return
+
+    benchmark_metrics = calculate_benchmark_relative_metrics(results, benchmark_data)
+    if benchmark_metrics["Benchmark Observations"] == 0:
+        st.warning(
+            "Benchmark comparison unavailable: no overlapping benchmark data "
+            f"for {BENCHMARK_TICKER}."
+        )
+        return
+
+    display_benchmark_metrics(benchmark_metrics, BENCHMARK_TICKER)
 
 
 # Trading strategy preparation functions
@@ -776,6 +844,7 @@ def main():
         )
 
     display_performance_metrics(metrics, company_display)
+    _display_benchmark_comparison(results, backtest_data)
     plot_equity_curve(
         results,
         ticker_display,

--- a/src/quant_trading_strategy_backtester/benchmark.py
+++ b/src/quant_trading_strategy_backtester/benchmark.py
@@ -1,0 +1,167 @@
+"""
+Calculate benchmark-relative performance metrics.
+"""
+
+import math
+
+import numpy as np
+import polars as pl
+
+from quant_trading_strategy_backtester.backtester import TRADING_DAYS_PER_YEAR
+
+BENCHMARK_TICKER = "SPY"
+
+
+def calculate_benchmark_relative_metrics(
+    strategy_results: pl.DataFrame,
+    benchmark_data: pl.DataFrame,
+    risk_free_return_rate_annual: float = 0.0,
+) -> dict[str, float]:
+    """
+    Calculate strategy performance relative to a benchmark return stream.
+
+    Args:
+        strategy_results: Backtest results containing Date and strategy_returns.
+        benchmark_data: Benchmark price data containing Date and Close.
+        risk_free_return_rate_annual: Annualised risk-free return rate.
+
+    Returns:
+        Benchmark-relative metrics aligned on common trading dates.
+
+    Raises:
+        ValueError: If required columns are missing.
+    """
+    _validate_columns(strategy_results, {"Date", "strategy_returns"}, "strategy")
+    _validate_columns(benchmark_data, {"Date", "Close"}, "benchmark")
+
+    if strategy_results.is_empty() or benchmark_data.is_empty():
+        return _undefined_metrics(0)
+
+    strategy_returns_data = (
+        strategy_results.select(["Date", "strategy_returns"])
+        .sort("Date")
+        .with_columns(pl.col("Date").shift(1).alias("strategy_previous_date"))
+    )
+    benchmark_returns = (
+        benchmark_data.select(["Date", "Close"])
+        .sort("Date")
+        .with_columns(
+            [
+                pl.col("Date").shift(1).alias("benchmark_previous_date"),
+                ((pl.col("Close") / pl.col("Close").shift(1)) - 1)
+                .fill_null(0)
+                .alias("benchmark_returns"),
+            ]
+        )
+        .select(["Date", "benchmark_previous_date", "benchmark_returns"])
+    )
+    aligned_returns = (
+        strategy_returns_data.join(benchmark_returns, on="Date", how="inner")
+        .filter(
+            (
+                pl.col("strategy_previous_date").is_null()
+                & pl.col("benchmark_previous_date").is_null()
+            )
+            | (pl.col("strategy_previous_date") == pl.col("benchmark_previous_date"))
+        )
+        .drop_nulls(["strategy_returns", "benchmark_returns"])
+        .sort("Date")
+    )
+
+    if aligned_returns.height < 2:
+        return _undefined_metrics(aligned_returns.height)
+
+    strategy_returns = aligned_returns["strategy_returns"].cast(pl.Float64).to_numpy()
+    benchmark_returns_array = (
+        aligned_returns["benchmark_returns"].cast(pl.Float64).to_numpy()
+    )
+    finite_mask = np.isfinite(strategy_returns) & np.isfinite(benchmark_returns_array)
+    strategy_returns = strategy_returns[finite_mask]
+    benchmark_returns_array = benchmark_returns_array[finite_mask]
+
+    if len(strategy_returns) < 2:
+        return _undefined_metrics(len(strategy_returns))
+
+    strategy_total_return = float(np.prod(1 + strategy_returns) - 1)
+    benchmark_total_return = float(np.prod(1 + benchmark_returns_array) - 1)
+    excess_return = strategy_total_return - benchmark_total_return
+
+    periods = TRADING_DAYS_PER_YEAR
+    rf_daily = (1 + risk_free_return_rate_annual) ** (1 / periods) - 1
+    strategy_excess_returns = strategy_returns - rf_daily
+    benchmark_excess_returns = benchmark_returns_array - rf_daily
+
+    beta = _calculate_beta(strategy_excess_returns, benchmark_excess_returns)
+    alpha = (
+        float(
+            (
+                np.mean(strategy_excess_returns)
+                - beta * np.mean(benchmark_excess_returns)
+            )
+            * periods
+        )
+        if math.isfinite(beta)
+        else float("nan")
+    )
+    information_ratio = _calculate_information_ratio(
+        strategy_returns - benchmark_returns_array
+    )
+
+    return {
+        "Strategy Aligned Total Return": strategy_total_return,
+        "Benchmark Total Return": benchmark_total_return,
+        "Excess Return": excess_return,
+        "Beta": beta,
+        "Alpha": alpha,
+        "Information Ratio": information_ratio,
+        "Benchmark Observations": float(len(strategy_returns)),
+    }
+
+
+def _validate_columns(
+    data: pl.DataFrame, required_columns: set[str], label: str
+) -> None:
+    """Raise if a DataFrame is missing required columns."""
+    missing_columns = required_columns - set(data.columns)
+    if missing_columns:
+        raise ValueError(
+            f"{label.title()} data missing required columns: {sorted(missing_columns)}"
+        )
+
+
+def _calculate_beta(
+    strategy_excess_returns: np.ndarray, benchmark_excess_returns: np.ndarray
+) -> float:
+    """Calculate strategy beta to the benchmark return stream."""
+    benchmark_variance = float(np.var(benchmark_excess_returns, ddof=1))
+    if not math.isfinite(benchmark_variance) or np.isclose(benchmark_variance, 0.0):
+        return float("nan")
+
+    covariance = float(np.cov(strategy_excess_returns, benchmark_excess_returns)[0, 1])
+    return covariance / benchmark_variance
+
+
+def _calculate_information_ratio(active_returns: np.ndarray) -> float:
+    """Calculate annualised information ratio from active returns."""
+    active_return_std = float(np.std(active_returns, ddof=1))
+    if not math.isfinite(active_return_std) or np.isclose(active_return_std, 0.0):
+        return float("nan")
+
+    return float(
+        (TRADING_DAYS_PER_YEAR**0.5)
+        * float(np.mean(active_returns))
+        / active_return_std
+    )
+
+
+def _undefined_metrics(observations: int) -> dict[str, float]:
+    """Return undefined benchmark-relative metrics with an observation count."""
+    return {
+        "Strategy Aligned Total Return": float("nan"),
+        "Benchmark Total Return": float("nan"),
+        "Excess Return": float("nan"),
+        "Beta": float("nan"),
+        "Alpha": float("nan"),
+        "Information Ratio": float("nan"),
+        "Benchmark Observations": float(observations),
+    }

--- a/src/quant_trading_strategy_backtester/visualisation.py
+++ b/src/quant_trading_strategy_backtester/visualisation.py
@@ -67,6 +67,34 @@ def display_performance_metrics(
         )
 
 
+def display_benchmark_metrics(metrics: dict[str, float], benchmark_ticker: str) -> None:
+    """
+    Display benchmark-relative performance metrics.
+
+    Args:
+        metrics: A dictionary containing benchmark-relative metrics.
+        benchmark_ticker: The ticker symbol used as the benchmark.
+    """
+    st.subheader(f"Benchmark Comparison vs. {benchmark_ticker}")
+    benchmark_return_col, excess_return_col, beta_col = st.columns(3)
+    benchmark_return_col.metric(
+        "Benchmark Return", _format_metric(metrics["Benchmark Total Return"], ".4%")
+    )
+    excess_return_col.metric(
+        "Excess Return", _format_metric(metrics["Excess Return"], ".4%")
+    )
+    beta_col.metric("Beta", _format_metric(metrics["Beta"], ".4f"))
+
+    alpha_col, information_ratio_col, observations_col = st.columns(3)
+    alpha_col.metric("Annualised Alpha", _format_metric(metrics["Alpha"], ".4%"))
+    information_ratio_col.metric(
+        "Information Ratio", _format_metric(metrics["Information Ratio"], ".4f")
+    )
+    observations_col.metric(
+        "Aligned Days", _format_metric(metrics["Benchmark Observations"], ".0f")
+    )
+
+
 def plot_equity_curve(
     results: pl.DataFrame,
     ticker_display: str,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,27 @@
+"""
+Tests for Streamlit app helpers.
+"""
+
+import datetime
+
+import polars as pl
+
+from quant_trading_strategy_backtester.app import _get_benchmark_date_range
+
+
+def test_get_benchmark_date_range_uses_exclusive_yahoo_end_date() -> None:
+    """Verify benchmark loading includes the displayed final backtest date."""
+    data = pl.DataFrame(
+        {
+            "Date": [
+                datetime.datetime(2020, 1, 2, 0, 0),
+                datetime.datetime(2020, 1, 3, 0, 0),
+            ],
+            "Close": [100.0, 101.0],
+        }
+    )
+
+    start_date, end_date = _get_benchmark_date_range(data)
+
+    assert start_date == datetime.date(2020, 1, 2)
+    assert end_date == datetime.date(2020, 1, 4)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,120 @@
+"""
+Tests for benchmark-relative reporting.
+"""
+
+import datetime
+import math
+
+import numpy as np
+import polars as pl
+import pytest
+
+from quant_trading_strategy_backtester.backtester import TRADING_DAYS_PER_YEAR
+from quant_trading_strategy_backtester.benchmark import (
+    calculate_benchmark_relative_metrics,
+)
+
+
+def test_calculate_benchmark_relative_metrics() -> None:
+    """Verify benchmark-relative metrics are calculated from aligned returns."""
+    dates = [datetime.date(2020, 1, 1) + datetime.timedelta(days=i) for i in range(4)]
+    strategy_returns = np.array([0.0, 0.02, -0.01, 0.03])
+    benchmark_returns = np.array([0.0, 0.01, 0.0, 0.02])
+    strategy_results = pl.DataFrame(
+        {"Date": dates, "strategy_returns": strategy_returns}
+    )
+    benchmark_data = pl.DataFrame(
+        {
+            "Date": dates,
+            "Close": [100.0, 101.0, 101.0, 103.02],
+        }
+    )
+
+    metrics = calculate_benchmark_relative_metrics(strategy_results, benchmark_data)
+
+    strategy_total_return = float(np.prod(1 + strategy_returns) - 1)
+    benchmark_total_return = float(np.prod(1 + benchmark_returns) - 1)
+    beta = float(np.cov(strategy_returns, benchmark_returns)[0, 1]) / float(
+        np.var(benchmark_returns, ddof=1)
+    )
+    alpha = float(
+        (np.mean(strategy_returns) - beta * np.mean(benchmark_returns))
+        * TRADING_DAYS_PER_YEAR
+    )
+    active_returns = strategy_returns - benchmark_returns
+    information_ratio = float(
+        (TRADING_DAYS_PER_YEAR**0.5)
+        * float(np.mean(active_returns))
+        / float(np.std(active_returns, ddof=1))
+    )
+
+    assert metrics["Strategy Aligned Total Return"] == pytest.approx(
+        strategy_total_return
+    )
+    assert metrics["Benchmark Total Return"] == pytest.approx(benchmark_total_return)
+    assert metrics["Excess Return"] == pytest.approx(
+        strategy_total_return - benchmark_total_return
+    )
+    assert metrics["Beta"] == pytest.approx(beta)
+    assert metrics["Alpha"] == pytest.approx(alpha)
+    assert metrics["Information Ratio"] == pytest.approx(information_ratio)
+    assert metrics["Benchmark Observations"] == 4
+
+
+def test_calculate_benchmark_relative_metrics_drops_mismatched_return_periods() -> None:
+    """Verify benchmark metrics ignore mismatched return intervals."""
+    strategy_results = pl.DataFrame(
+        {
+            "Date": [
+                datetime.date(2020, 1, 1),
+                datetime.date(2020, 1, 2),
+                datetime.date(2020, 1, 3),
+            ],
+            "strategy_returns": [0.0, 0.02, 0.03],
+        }
+    )
+    benchmark_data = pl.DataFrame(
+        {
+            "Date": [
+                datetime.date(2020, 1, 1),
+                datetime.date(2020, 1, 3),
+            ],
+            "Close": [100.0, 101.0],
+        }
+    )
+
+    metrics = calculate_benchmark_relative_metrics(strategy_results, benchmark_data)
+
+    assert math.isnan(metrics["Strategy Aligned Total Return"])
+    assert math.isnan(metrics["Benchmark Total Return"])
+    assert metrics["Benchmark Observations"] == 1
+
+
+def test_calculate_benchmark_relative_metrics_handles_constant_benchmark() -> None:
+    """Verify undefined relative metrics are displayed as NaN when needed."""
+    dates = [datetime.date(2020, 1, 1) + datetime.timedelta(days=i) for i in range(3)]
+    strategy_results = pl.DataFrame(
+        {"Date": dates, "strategy_returns": [0.0, 0.01, -0.005]}
+    )
+    benchmark_data = pl.DataFrame({"Date": dates, "Close": [100.0, 100.0, 100.0]})
+
+    metrics = calculate_benchmark_relative_metrics(strategy_results, benchmark_data)
+
+    assert math.isnan(metrics["Beta"])
+    assert math.isnan(metrics["Alpha"])
+    assert math.isfinite(metrics["Information Ratio"])
+    assert metrics["Benchmark Observations"] == 3
+
+
+def test_calculate_benchmark_relative_metrics_requires_columns() -> None:
+    """Verify missing strategy or benchmark columns fail clearly."""
+    data = pl.DataFrame({"Date": [datetime.date(2020, 1, 1)]})
+
+    with pytest.raises(ValueError, match="Strategy"):
+        calculate_benchmark_relative_metrics(data, data.with_columns(pl.lit(1.0)))
+
+    with pytest.raises(ValueError, match="Benchmark"):
+        calculate_benchmark_relative_metrics(
+            data.with_columns(pl.lit(0.0).alias("strategy_returns")),
+            data,
+        )


### PR DESCRIPTION
# Summary
- Added benchmark-relative reporting for displayed backtest results
  - Compared strategy returns against SPY over the same rendered period rather than the configured date range
  - Reported excess return, beta, annualised alpha, information ratio, and aligned observations alongside existing performance metrics
- Aligned benchmark and strategy return streams before calculating relative metrics
  - Dropped mismatched return intervals so missing benchmark dates do not compare multi-day SPY moves with one-day strategy returns
- Covered benchmark calculations and benchmark date loading with regression tests
- Updated README with the new SPY comparison and date-alignment methodology

## Rationale
- SPY is a lightweight default benchmark for this app’s current equity-focused workflows – it gives users an immediate market-relative sanity check without adding more sidebar configuration
- Return interval alignment matters more than date overlap alone
  - Without it, a missing benchmark date could silently compare a multi-day SPY move with a one-day strategy return and distort beta, alpha, and information ratio

## Manual Test Evidence
- Opened the local Streamlit app at `http://127.0.0.1:8501` and confirmed `Benchmark Comparison vs. SPY` rendered real values without a benchmark warning or traceback