### PR TITLE
feat: Add risk and optimisation reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ _Try the deployed app
   backtesting, and analysis
 - **Trade and spread visualisation** – equity curves with trade markers and
   pairs spread z-score charts with entry/exit threshold bands
-- **Performance metrics** – Total Return, Sharpe Ratio, Max Drawdown, and
-  monthly performance table with rolling returns
+- **Performance metrics** – total return, Sharpe, Sortino, Calmar, drawdown
+  depth/duration, and monthly performance table with rolling returns
 - **Real-time data fetching** – adjusted historical market data from Yahoo
   Finance
 
@@ -49,6 +49,9 @@ _Try the deployed app
   look-ahead bias
 - **Benchmark comparison** aligns the strategy and SPY return streams by date
   over the displayed backtest period before calculating relative metrics
+- **Optimisation reporting** shows valid parameter combinations, candidate
+  ticker/pair counts, and whether displayed results come from full-period,
+  held-out, or walk-forward evaluation
 - **Walk-forward validation** uses expanding training windows for more
   robust out-of-sample evaluation – recommended over the default split
 - **Survivorship bias** remains a limitation – automatic ticker selection uses

--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -91,13 +91,26 @@ def _get_final_backtest_data(
         optimised backtests.
     """
     if not use_validation_data:
+        st.info(
+            f"Displaying full-period backtest results over {len(data)} rows. "
+            "No ticker-selection or parameter-optimisation split was applied."
+        )
         return data
 
     validation_data = get_validation_data(data, walk_forward=walk_forward)
+    training_data = get_training_data(data, walk_forward=walk_forward)
     if walk_forward:
-        st.info("Displaying final walk-forward test-fold backtest results.")
+        st.info(
+            "Displaying final walk-forward test-fold backtest results "
+            f"over {len(validation_data)} rows after expanding-window "
+            f"optimisation on {len(training_data)} prior rows."
+        )
     else:
-        st.info("Displaying held-out test-period backtest results.")
+        st.info(
+            "Displaying held-out test-period backtest results over "
+            f"{len(validation_data)} rows after selection or optimisation "
+            f"on {len(training_data)} training rows."
+        )
     return validation_data
 
 

--- a/src/quant_trading_strategy_backtester/backtester.py
+++ b/src/quant_trading_strategy_backtester/backtester.py
@@ -8,6 +8,7 @@ this repository.
 """
 
 import json
+import math
 import platform
 from datetime import date, datetime
 from typing import Any
@@ -193,6 +194,88 @@ def _optional_float(row: dict[str, Any], name: str) -> float | None:
         return None
 
     return float(value)
+
+
+def _finite_values(series: pl.Series) -> list[float]:
+    """Return finite float values from a Polars series."""
+    values = []
+    for value in series:
+        if value is None:
+            continue
+        float_value = float(value)
+        if math.isfinite(float_value):
+            values.append(float_value)
+
+    return values
+
+
+def _calculate_sharpe_ratio(excess_returns: list[float]) -> float:
+    """Calculate annualised Sharpe ratio from daily excess returns."""
+    if len(excess_returns) < 2:
+        return float("nan")
+
+    returns_mean = sum(excess_returns) / len(excess_returns)
+    returns_variance = sum(
+        (return_value - returns_mean) ** 2 for return_value in excess_returns
+    ) / (len(excess_returns) - 1)
+    returns_std = math.sqrt(returns_variance)
+    if not returns_std or not math.isfinite(returns_std):
+        return float("nan")
+
+    return float((TRADING_DAYS_PER_YEAR**0.5) * returns_mean / returns_std)
+
+
+def _calculate_sortino_ratio(excess_returns: list[float]) -> float:
+    """Calculate annualised Sortino ratio from daily excess returns."""
+    if not excess_returns:
+        return float("nan")
+
+    downside_deviation = math.sqrt(
+        sum(min(return_value, 0.0) ** 2 for return_value in excess_returns)
+        / len(excess_returns)
+    )
+    if not downside_deviation or not math.isfinite(downside_deviation):
+        return float("nan")
+
+    returns_mean = sum(excess_returns) / len(excess_returns)
+    return float((TRADING_DAYS_PER_YEAR**0.5) * returns_mean / downside_deviation)
+
+
+def _calculate_max_drawdown_duration(drawdowns: pl.Series) -> float:
+    """Calculate the longest drawdown duration in trading rows."""
+    max_duration = 0
+    current_duration = 0
+
+    for value in drawdowns:
+        if value is None:
+            current_duration = 0
+            continue
+
+        drawdown = float(value)
+        if math.isfinite(drawdown) and drawdown < 0:
+            current_duration += 1
+            max_duration = max(max_duration, current_duration)
+        else:
+            current_duration = 0
+
+    return float(max_duration)
+
+
+def _calculate_calmar_ratio(
+    total_return: float, max_drawdown: float, periods: int
+) -> float:
+    """Calculate annualised return divided by absolute maximum drawdown."""
+    if (
+        periods <= 0
+        or total_return <= -1
+        or not math.isfinite(total_return)
+        or not math.isfinite(max_drawdown)
+        or math.isclose(max_drawdown, 0.0)
+    ):
+        return float("nan")
+
+    annualised_return = (1 + total_return) ** (TRADING_DAYS_PER_YEAR / periods) - 1
+    return float(annualised_return / abs(max_drawdown))
 
 
 class Backtester:
@@ -463,29 +546,34 @@ class Backtester:
         trade_events = float(self.results.filter(pl.col("trade_turnover") > 0).height)
 
         # Measure the risk-adjusted return.
-        periods = TRADING_DAYS_PER_YEAR
-        rf_daily = (1 + risk_free_return_rate_annual) ** (1 / periods) - 1
-        excess = self.results["strategy_returns"].cast(pl.Float64) - rf_daily
-        returns_mean = float(excess.mean())
-        returns_std = float(excess.std())
-        sharpe_ratio = (
-            float((periods**0.5) * returns_mean / returns_std)
-            if returns_std
-            else float("nan")
+        rf_daily = (1 + risk_free_return_rate_annual) ** (1 / TRADING_DAYS_PER_YEAR) - 1
+        excess_returns = _finite_values(
+            self.results["strategy_returns"].cast(pl.Float64) - rf_daily
         )
+        sharpe_ratio = _calculate_sharpe_ratio(excess_returns)
+        sortino_ratio = _calculate_sortino_ratio(excess_returns)
 
         # Measure the maximum loss from a peak to a trough of the equity curve.
         drawdowns = (
             self.results["equity_curve"] / self.results["equity_curve"].cum_max() - 1
         )
         max_drawdown = float(drawdowns.cast(pl.Float64).min())  # type: ignore
+        max_drawdown_duration = _calculate_max_drawdown_duration(
+            drawdowns.cast(pl.Float64)
+        )
+        calmar_ratio = _calculate_calmar_ratio(
+            total_return, max_drawdown, max(len(self.results) - 1, 1)
+        )
 
         # TODO: Split the calculations out into separate functions.
         return {
             "Total Return": total_return,
             "Gross Total Return": gross_total_return,
             "Sharpe Ratio": sharpe_ratio,
+            "Sortino Ratio": sortino_ratio,
+            "Calmar Ratio": calmar_ratio,
             "Max Drawdown": max_drawdown,
+            "Max Drawdown Duration": max_drawdown_duration,
             "Total Costs": total_costs,
             "Cost Drag": gross_total_return - total_return,
             "Trade Events": trade_events,

--- a/src/quant_trading_strategy_backtester/optimiser.py
+++ b/src/quant_trading_strategy_backtester/optimiser.py
@@ -7,6 +7,7 @@ import datetime
 import itertools
 import math
 import time
+from collections.abc import Mapping
 from typing import Any, cast
 
 import polars as pl
@@ -130,6 +131,48 @@ def _optimisation_score(
     return score
 
 
+def count_valid_parameter_combinations(
+    strategy_type: str,
+    parameter_ranges: Mapping[str, range | list[int | float] | int | float],
+) -> int:
+    """Return the number of valid scalar parameter combinations."""
+    return len(_valid_parameter_combinations(strategy_type, parameter_ranges))
+
+
+def count_candidate_pairs(top_companies: list[tuple[str, float]]) -> int:
+    """Return pair candidates after same-company filtering."""
+    return len(_candidate_pairs(top_companies))
+
+
+def _display_parameter_search_context(
+    data: pl.DataFrame,
+    strategy_type: str,
+    parameter_ranges: Mapping[str, range | list[int | float] | int | float],
+    walk_forward: bool,
+) -> None:
+    """Display durable Streamlit context for parameter optimisation."""
+    valid_combinations = count_valid_parameter_combinations(
+        strategy_type, parameter_ranges
+    )
+    if walk_forward:
+        st.info(
+            "Parameter optimisation tests "
+            f"{valid_combinations} valid combinations across "
+            f"{WALK_FORWARD_FOLDS} expanding walk-forward folds. "
+            "Displayed optimisation metrics are aggregated out-of-sample "
+            "fold results."
+        )
+        return
+
+    train_data, test_data = _split_data(data)
+    st.info(
+        "Parameter optimisation tests "
+        f"{valid_combinations} valid combinations on {len(train_data)} "
+        f"training rows. Displayed optimisation metrics use {len(test_data)} "
+        "held-out test rows."
+    )
+
+
 def run_optimisation(
     data: pl.DataFrame,
     strategy_type: str,
@@ -166,6 +209,12 @@ def run_optimisation(
         )
         st.success(f"Best ticker for Buy and Hold: {best_ticker}")
     elif walk_forward:
+        _display_parameter_search_context(
+            data,
+            strategy_type,
+            cast(dict[str, range | list[int | float] | int | float], strategy_params),
+            walk_forward=True,
+        )
         strategy_params, metrics, fold_results = walk_forward_optimise(
             data,
             strategy_type,
@@ -175,6 +224,12 @@ def run_optimisation(
         _display_walk_forward_results(fold_results)
     else:
         train_data, test_data = _split_data(data)
+        _display_parameter_search_context(
+            data,
+            strategy_type,
+            cast(dict[str, range | list[int | float] | int | float], strategy_params),
+            walk_forward=False,
+        )
         strategy_params, metrics = optimise_strategy_params(
             train_data,
             strategy_type,
@@ -244,6 +299,7 @@ def optimise_buy_and_hold_ticker(
     best_ticker = None
     best_test_data = None
     best_total_return = float("-inf")
+    evaluated_tickers = 0
 
     total_tickers = len(top_companies)
     progress_bar = st.progress(0)
@@ -257,6 +313,7 @@ def optimise_buy_and_hold_ticker(
         if data is None or data.is_empty():
             continue
 
+        evaluated_tickers += 1
         train_data, test_data = _split_data(data)
 
         backtester = Backtester(train_data, BuyAndHoldStrategy({}), tickers=ticker)
@@ -274,6 +331,11 @@ def optimise_buy_and_hold_ticker(
 
     progress_bar.empty()
     status_text.empty()
+    st.info(
+        f"Ticker selection evaluated {evaluated_tickers} of {total_tickers} "
+        "candidates. Ranking used the training split and final metrics use "
+        "the held-out test split."
+    )
 
     if not best_ticker or best_test_data is None:
         raise ValueError("Buy and Hold optimisation failed")
@@ -313,6 +375,7 @@ def optimise_single_ticker_strategy_ticker(
     """
     best_ticker = None
     best_sharpe_ratio = float("-inf")
+    evaluated_tickers = 0
 
     total_tickers = len(top_companies)
     progress_bar = st.progress(0)
@@ -332,6 +395,7 @@ def optimise_single_ticker_strategy_ticker(
         if data is None or data.is_empty():
             continue
 
+        evaluated_tickers += 1
         train_data, _ = _split_data(data)
         _, train_metrics = run_backtest(train_data, strategy_type, fixed_params, ticker)
 
@@ -342,6 +406,11 @@ def optimise_single_ticker_strategy_ticker(
 
     progress_bar.empty()
     status_text.empty()
+    st.info(
+        f"Ticker selection evaluated {evaluated_tickers} of {total_tickers} "
+        "candidates. Ranking used the training split; displayed results use "
+        "the validation split."
+    )
 
     if not best_ticker:
         raise ValueError("Single ticker strategy ticker optimisation failed")
@@ -448,15 +517,21 @@ def optimise_pairs_trading_tickers(
     best_params = None
     best_test_data = None
     best_sharpe_ratio = float("-inf")
+    evaluated_pairs = 0
 
-    ticker_pairs = list(
-        itertools.combinations([company[0] for company in top_companies], 2)
-    )
-    # Filter out pairs that likely represent the same company
-    ticker_pairs = [
-        pair for pair in ticker_pairs if not is_same_company(pair[0], pair[1])
-    ]
+    ticker_pairs = _candidate_pairs(top_companies)
     total_combinations = len(ticker_pairs)
+    parameter_combinations = 0
+    optimisation_parameter_ranges = None
+    if optimise:
+        optimisation_parameter_ranges = {
+            k: [v] if isinstance(v, (int, float)) else v
+            for k, v in strategy_params.items()
+        }
+        parameter_combinations = count_valid_parameter_combinations(
+            "Pairs Trading", optimisation_parameter_ranges
+        )
+
     # Display progress bar and status text, as this process may take a while.
     progress_bar = st.progress(0)
     status_text = st.empty()
@@ -475,6 +550,7 @@ def optimise_pairs_trading_tickers(
         if data is None or data.is_empty():
             continue
 
+        evaluated_pairs += 1
         train_data, test_data = _split_data(data)
         cointegration_result = evaluate_cointegration(
             train_data,
@@ -487,15 +563,13 @@ def optimise_pairs_trading_tickers(
             continue
 
         if optimise:
-            # Convert single values to lists for optimisation
-            param_ranges = {
-                k: [v] if isinstance(v, (int, float)) else v
-                for k, v in strategy_params.items()
-            }
             current_params, train_metrics = optimise_strategy_params(
                 train_data,
                 "Pairs Trading",
-                param_ranges,
+                cast(
+                    dict[str, range | list[int | float]],
+                    optimisation_parameter_ranges,
+                ),
                 [ticker1, ticker2],
             )
         else:
@@ -521,6 +595,21 @@ def optimise_pairs_trading_tickers(
             "Pairs trading optimisation failed: no cointegrated pair produced "
             f"a finite Sharpe ratio ({rejected_pairs} pairs rejected by "
             "cointegration filter)"
+        )
+
+    cointegrated_pairs = evaluated_pairs - rejected_pairs
+    st.info(
+        f"Pair selection evaluated {evaluated_pairs} of {total_combinations} "
+        f"candidate pairs. The cointegration filter rejected {rejected_pairs}; "
+        "ranking used the training split and final metrics use the held-out "
+        "test split."
+    )
+    if optimise:
+        st.info(
+            "Pair parameter optimisation tested "
+            f"{parameter_combinations} valid combinations per cointegrated "
+            f"pair ({cointegrated_pairs * parameter_combinations} training "
+            "backtests)."
         )
 
     _, best_metrics = run_backtest(
@@ -623,7 +712,7 @@ def walk_forward_optimise(
 
 def _valid_parameter_combinations(
     strategy_type: str,
-    parameter_ranges: dict[str, range | list[int | float]],
+    parameter_ranges: Mapping[str, range | list[int | float] | int | float],
 ) -> list[dict[str, int | float]]:
     """
     Return scalar parameter combinations that pass strategy validation.
@@ -636,10 +725,7 @@ def _valid_parameter_combinations(
         Valid scalar parameter dictionaries for grid search.
     """
     param_names = list(parameter_ranges.keys())
-    param_values = [
-        list(value) if isinstance(value, range) else value
-        for value in parameter_ranges.values()
-    ]
+    param_values = [_parameter_values(value) for value in parameter_ranges.values()]
 
     return [
         current_params
@@ -648,6 +734,26 @@ def _valid_parameter_combinations(
             strategy_type, current_params := dict(zip(param_names, params))
         )
     ]
+
+
+def _parameter_values(
+    value: range | list[int | float] | int | float,
+) -> list[int | float]:
+    """Return parameter candidate values from ranges, lists, or scalars."""
+    if isinstance(value, range):
+        return list(value)
+    if isinstance(value, list):
+        return value
+
+    return [value]
+
+
+def _candidate_pairs(top_companies: list[tuple[str, float]]) -> list[tuple[str, str]]:
+    """Return ticker pairs after excluding likely same-company pairs."""
+    ticker_pairs = list(
+        itertools.combinations([company[0] for company in top_companies], 2)
+    )
+    return [pair for pair in ticker_pairs if not is_same_company(pair[0], pair[1])]
 
 
 def run_backtest(

--- a/src/quant_trading_strategy_backtester/visualisation.py
+++ b/src/quant_trading_strategy_backtester/visualisation.py
@@ -42,6 +42,23 @@ def display_performance_metrics(
     )
 
     if {
+        "Sortino Ratio",
+        "Calmar Ratio",
+        "Max Drawdown Duration",
+    }.issubset(metrics):
+        sortino_col, calmar_col, drawdown_duration_col = st.columns(3)
+        sortino_col.metric(
+            "Sortino Ratio", _format_metric(metrics["Sortino Ratio"], ".4f")
+        )
+        calmar_col.metric(
+            "Calmar Ratio", _format_metric(metrics["Calmar Ratio"], ".4f")
+        )
+        drawdown_duration_col.metric(
+            "Max Drawdown Duration",
+            _format_metric(metrics["Max Drawdown Duration"], ".0f"),
+        )
+
+    if {
         "Gross Total Return",
         "Total Costs",
         "Cost Drag",

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -8,7 +8,11 @@ from typing import Any
 
 import polars as pl
 import pytest
-from quant_trading_strategy_backtester.backtester import Backtester, build_trade_ledger
+from quant_trading_strategy_backtester.backtester import (
+    TRADING_DAYS_PER_YEAR,
+    Backtester,
+    build_trade_ledger,
+)
 from quant_trading_strategy_backtester.models import StrategyModel
 from quant_trading_strategy_backtester.strategies.base import BaseStrategy
 from quant_trading_strategy_backtester.strategies.buy_and_hold import BuyAndHoldStrategy
@@ -171,7 +175,10 @@ def test_backtester_get_performance_metrics(
         "Total Return",
         "Gross Total Return",
         "Sharpe Ratio",
+        "Sortino Ratio",
+        "Calmar Ratio",
         "Max Drawdown",
+        "Max Drawdown Duration",
         "Total Costs",
         "Cost Drag",
         "Trade Events",
@@ -438,6 +445,57 @@ def test_backtester_reports_cost_attribution_metrics():
     assert metrics["Cost Drag"] > 0
     assert metrics["Trade Events"] == 2
     assert metrics["Total Turnover"] == 2
+
+
+def test_backtester_reports_downside_and_drawdown_risk_metrics() -> None:
+    """
+    Verify downside risk, drawdown depth, and drawdown duration metrics.
+    """
+    dates = [datetime.date(2020, 1, 1) + datetime.timedelta(days=i) for i in range(6)]
+    strategy_returns = [0.0, -0.1, -1 / 9, 0.375, -1 / 11, 0.2]
+    equity_curve = [100_000.0, 90_000.0, 80_000.0, 110_000.0, 100_000.0, 120_000.0]
+    cumulative_returns = [equity / 100_000.0 for equity in equity_curve]
+    results = pl.DataFrame(
+        {
+            "Date": dates,
+            "signal": [1.0] * 6,
+            "position_change": [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            "gross_strategy_returns": strategy_returns,
+            "strategy_returns": strategy_returns,
+            "transaction_costs": [0.0] * 6,
+            "trade_turnover": [0.0] * 6,
+            "gross_cumulative_returns": cumulative_returns,
+            "cumulative_returns": cumulative_returns,
+            "cumulative_transaction_costs": [0.0] * 6,
+            "equity_curve": equity_curve,
+        }
+    )
+    backtester = Backtester(
+        pl.DataFrame({"Date": dates, "Close": [100.0] * 6}),
+        BuyAndHoldStrategy({}),
+    )
+    backtester.results = results
+
+    metrics = backtester.get_performance_metrics()
+    assert metrics is not None
+
+    downside_deviation = math.sqrt(
+        sum(min(return_value, 0.0) ** 2 for return_value in strategy_returns)
+        / len(strategy_returns)
+    )
+    expected_sortino = (
+        (TRADING_DAYS_PER_YEAR**0.5)
+        * (sum(strategy_returns) / len(strategy_returns))
+        / downside_deviation
+    )
+    expected_calmar = (
+        1.2 ** (TRADING_DAYS_PER_YEAR / (len(strategy_returns) - 1)) - 1
+    ) / 0.2
+
+    assert metrics["Sortino Ratio"] == pytest.approx(expected_sortino)
+    assert metrics["Calmar Ratio"] == pytest.approx(expected_calmar)
+    assert metrics["Max Drawdown"] == pytest.approx(-0.2)
+    assert metrics["Max Drawdown Duration"] == 2
 
 
 def test_default_transaction_costs_reduce_returns():

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -18,6 +18,8 @@ from quant_trading_strategy_backtester.app import (
 from quant_trading_strategy_backtester.cointegration import CointegrationResult
 from quant_trading_strategy_backtester.optimiser import (
     _split_data,
+    count_candidate_pairs,
+    count_valid_parameter_combinations,
     get_training_data,
     get_validation_data,
     optimise_buy_and_hold_ticker,
@@ -41,6 +43,36 @@ def _cointegration_result(is_cointegrated: bool) -> CointegrationResult:
         critical_value_10pct=-3.0,
         reason=None if is_cointegrated else "Pair is not cointegrated",
     )
+
+
+def test_count_valid_parameter_combinations_filters_invalid_combinations() -> None:
+    """Verify optimisation reporting counts valid grid candidates only."""
+    assert (
+        count_valid_parameter_combinations(
+            "Moving Average Crossover",
+            {"short_window": [10, 30], "long_window": [20]},
+        )
+        == 1
+    )
+    assert (
+        count_valid_parameter_combinations(
+            "Moving Average Crossover",
+            {"short_window": 10, "long_window": 20},
+        )
+        == 1
+    )
+
+
+def test_count_candidate_pairs_excludes_same_company_pairs(monkeypatch) -> None:
+    """Verify pair reporting counts candidates after same-company filtering."""
+    top_companies = [("GOOG", 1.0), ("GOOGL", 0.9), ("MSFT", 0.8)]
+
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.is_same_company",
+        lambda ticker1, ticker2: {ticker1, ticker2} == {"GOOG", "GOOGL"},
+    )
+
+    assert count_candidate_pairs(top_companies) == 2
 
 
 def test_optimise_buy_and_hold_ticker(monkeypatch):


### PR DESCRIPTION
# Summary
- Added downside and drawdown risk reporting to the main backtest metrics
  - Displayed Sortino, Calmar, and max drawdown duration alongside the existing total return, Sharpe, and max drawdown metrics
  - Kept undefined risk values as `N/A` in the dashboard when the return stream does not support a meaningful ratio
- Added optimisation context for search and result interpretation
  - Reported valid parameter combinations, ticker or pair candidates evaluated, cointegration rejections, and train/test row counts where applicable
  - Labelled final displayed results as full-period, held-out split, or walk-forward test-fold output
- Covered the new reporting paths with focused regression tests
- Updated README methodology notes to reflect the broader risk metrics and optimisation transparency

## Related Issues
Fixes #45 

## Rationale
- These changes keep the PR in the interpretation layer – they make existing outputs harder to over-read without changing optimiser objectives or strategy behaviour
- Valid grid counts are based on the same parameter validation used by optimisation
  - This avoids claiming impossible combinations were tested when validation filters them out before backtesting

## Manual Test Evidence
- Opened the local Streamlit app at `http://127.0.0.1:8501` and confirmed the full-period path rendered Sortino, Calmar, max drawdown duration, and result-scope messaging without a traceback
- Enabled single-ticker parameter optimisation in the local app and confirmed valid-combination counts, train/test row counts, held-out result context, and risk metrics rendered without a traceback