### PR TITLE
fix: Handle maintenance commits in versioning

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -37,8 +37,17 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-          # Run commitizen bump (updates files only, no commit)
-          cz bump --yes --files-only
+          # Run commitizen bump (updates files only, no commit).
+          # Exit code 21 means no bump-worthy commits - exit
+          # gracefully as a safety net for unmapped prefixes.
+          cz bump --yes --files-only || {
+            rc=$?
+            if [ "$rc" -eq 21 ]; then
+              echo "No bump-worthy commits found, skipping."
+              exit 0
+            fi
+            exit "$rc"
+          }
 
           # Update lockfile to match new version
           uv lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,13 @@ dev = [
 app = "uv run streamlit run src/quant_trading_strategy_backtester/app.py"
 
 [tool.commitizen]
+name = "cz_customize"
 version = "0.8.1"
 version_files = [
     "pyproject.toml:version",
     "pyproject.toml:tool.commitizen.version",
 ]
+
+[tool.commitizen.customize]
+bump_pattern = "^((BREAKING[\\- ]CHANGE|\\w+)(\\(.+\\))?!?):"
+bump_map = { "^.+!$" = "MAJOR", "^BREAKING[\\- ]CHANGE" = "MAJOR", "^feat" = "MINOR", "^fix" = "PATCH", "^refactor" = "PATCH", "^perf" = "PATCH", "^build" = "PATCH", "^ci" = "PATCH", "^docs" = "PATCH", "^style" = "PATCH", "^test" = "PATCH", "^chore" = "PATCH" }


### PR DESCRIPTION
# Summary
- Extended Commitizen release classification so maintenance commit types produced patch releases while preserving feature and breaking-change increments
- Made version automation treat Commitizen's no-bump exit as a successful no-op while continuing to surface genuine failures

## Rationale
- `bump_map` overrides only apply through `cz_customize` – selecting that provider made the configured maintenance mappings effective
- Exit code `21` represents an expected state when no eligible commit exists – allowing it prevented harmless pushes from leaving `main` red
