### PR TITLE
chore: Migrate type checking from Ty to Pyrefly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,26 +5,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  type-check:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@main
-
-      - name: Set up Python 3.13
-        uses: actions/setup-python@main
-        with:
-          python-version: "3.13.x"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@main
-
-      - name: Install the project
-        run: uv sync --all-extras --dev
-
-      - name: Run Pyrefly
-        run: uv run pyrefly check
-
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install the project
         run: uv sync --all-extras --dev
 
+      - name: Run Pyrefly
+        run: uv run pyrefly check
+
       - name: Run tests with Pytest
         run:
           uv run coverage run --source=src/quant_trading_strategy_backtester -m

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,26 @@ on:
   workflow_dispatch:
 
 jobs:
+  type-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@main
+        with:
+          python-version: "3.13.x"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@main
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Run Pyrefly
+        run: uv run pyrefly check
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -28,9 +48,6 @@ jobs:
 
       - name: Install the project
         run: uv sync --all-extras --dev
-
-      - name: Run Pyrefly
-        run: uv run pyrefly check
 
       - name: Run tests with Pytest
         run:

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,0 +1,26 @@
+name: Type Check
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  type-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@main
+        with:
+          python-version: "3.13.x"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@main
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Run Pyrefly
+        run: uv run pyrefly check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
     "coverage<8.0.0,>=7.6.0",
     "pandas-stubs<3.0.0.0,>=2.2.2.240603",
     "pytest-cov<6.0.0,>=5.0.0",
-    "ty>=0.0.21",
+    "pyrefly>=1.2.0",
 ]
 
 [tool.uv]
@@ -49,6 +49,11 @@ constraint-dependencies = [
 
 [tool.poe.tasks]
 app = "uv run streamlit run src/quant_trading_strategy_backtester/app.py"
+
+[tool.pyrefly]
+project-includes = ["src", "tests", "scripts"]
+search-path = ["src", "tests"]
+python-version = "3.13"
 
 [tool.commitizen]
 name = "cz_customize"

--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -643,9 +643,9 @@ def display_historical_results():
             try:
                 params = json.loads(str(strategy.parameters))
             except (json.JSONDecodeError, TypeError):
-                params = strategy.parameters
+                params = cast(dict[str, Any], strategy.parameters)
             total_return = strategy.total_return
-            sharpe_ratio: float = strategy.sharpe_ratio  # type: ignore
+            sharpe_ratio = cast(float | None, strategy.sharpe_ratio)
             max_drawdown = strategy.max_drawdown
             start_date = strategy.start_date
             end_date = strategy.end_date
@@ -655,7 +655,7 @@ def display_historical_results():
             tickers = strategy["tickers"]
             params: dict = strategy["parameters"]
             total_return = strategy["total_return"]
-            sharpe_ratio: float = strategy["sharpe_ratio"]
+            sharpe_ratio: float | None = strategy["sharpe_ratio"]
             max_drawdown = strategy["max_drawdown"]
             start_date = strategy["start_date"]
             end_date = strategy["end_date"]

--- a/src/quant_trading_strategy_backtester/backtester.py
+++ b/src/quant_trading_strategy_backtester/backtester.py
@@ -11,7 +11,7 @@ import json
 import math
 import platform
 from datetime import UTC, date, datetime
-from typing import Any
+from typing import Any, cast
 
 import polars as pl
 import streamlit as st
@@ -84,7 +84,7 @@ def build_trade_ledger(results: pl.DataFrame) -> pl.DataFrame:
         )
 
     records: list[dict[str, Any]] = []
-    position_start_date: date | datetime | None = None
+    position_start_date: date | None = None
     previous_signal = 0.0
 
     for row in results.iter_rows(named=True):
@@ -168,8 +168,8 @@ def _classify_trade_reason(row: dict[str, Any], action: str) -> str:
 
 
 def _calculate_holding_period_days(
-    current_date: date | datetime,
-    position_start_date: date | datetime | None,
+    current_date: date,
+    position_start_date: date | None,
 ) -> int | None:
     """Return position age in calendar days for open or closing trades."""
     if position_start_date is None:
@@ -556,7 +556,7 @@ class Backtester:
         equity_curve = self.results["equity_curve"].cast(pl.Float64)
         running_peak = equity_curve.cum_max().clip(lower_bound=self.initial_capital)
         drawdowns = equity_curve / running_peak - 1
-        max_drawdown = float(drawdowns.cast(pl.Float64).min())  # type: ignore
+        max_drawdown = cast(float, drawdowns.cast(pl.Float64).min())
         max_drawdown_duration = _calculate_max_drawdown_duration(
             drawdowns.cast(pl.Float64)
         )

--- a/src/quant_trading_strategy_backtester/strategies/buy_and_hold.py
+++ b/src/quant_trading_strategy_backtester/strategies/buy_and_hold.py
@@ -43,7 +43,7 @@ class BuyAndHoldStrategy(BaseStrategy):
                 ]
             )
 
-        signals: pl.DataFrame = (  # type: ignore[invalid-assignment]
+        signals: pl.DataFrame = (
             data.select([pl.col("Date"), pl.col("Close")])
             .with_row_index()
             .lazy()

--- a/src/quant_trading_strategy_backtester/strategies/mean_reversion.py
+++ b/src/quant_trading_strategy_backtester/strategies/mean_reversion.py
@@ -70,7 +70,7 @@ class MeanReversionStrategy(BaseStrategy):
                 ]
             )
 
-        indicators: pl.DataFrame = (  # type: ignore[invalid-assignment]
+        indicators: pl.DataFrame = (
             data.select([pl.col("Date"), pl.col("Close")])
             .lazy()
             .with_columns(

--- a/src/quant_trading_strategy_backtester/strategies/moving_average_crossover.py
+++ b/src/quant_trading_strategy_backtester/strategies/moving_average_crossover.py
@@ -61,7 +61,7 @@ class MovingAverageCrossoverStrategy(BaseStrategy):
                 ]
             )
 
-        signals: pl.DataFrame = (  # type: ignore[invalid-assignment]
+        signals: pl.DataFrame = (
             data.select([pl.col("Date"), pl.col("Close")])
             .lazy()
             .with_columns(

--- a/src/quant_trading_strategy_backtester/strategies/pairs_trading.py
+++ b/src/quant_trading_strategy_backtester/strategies/pairs_trading.py
@@ -104,7 +104,7 @@ class PairsTradingStrategy(BaseStrategy):
             & (pl.col("spread_std") > 0)
         )
 
-        signals: pl.DataFrame = (  # type: ignore[invalid-assignment]
+        signals: pl.DataFrame = (
             data.select(
                 [
                     pl.col("Date"),

--- a/src/quant_trading_strategy_backtester/visualisation.py
+++ b/src/quant_trading_strategy_backtester/visualisation.py
@@ -301,7 +301,7 @@ def display_returns_by_month(results: pl.DataFrame) -> None:
         st.write("No data available for monthly performance calculation.")
         return
 
-    monthly_returns: pl.DataFrame = (  # type: ignore[invalid-assignment]
+    monthly_returns: pl.DataFrame = (
         results.lazy()
         .with_columns(pl.col("Date").dt.strftime("%Y-%m").alias("Month (YYYY-MM)"))
         .group_by("Month (YYYY-MM)")
@@ -326,7 +326,7 @@ def display_returns_by_month(results: pl.DataFrame) -> None:
         st.write("No monthly data available after aggregation.")
     else:
         initial_start_value = monthly_returns["start_value"][0]
-        monthly_returns: pl.DataFrame = (  # type: ignore[invalid-assignment]
+        monthly_returns: pl.DataFrame = (
             monthly_returns.lazy()
             .with_columns(
                 ((pl.col("end_value") / initial_start_value - 1) * 100).alias(

--- a/tests/strategies/test_base.py
+++ b/tests/strategies/test_base.py
@@ -31,14 +31,14 @@ from quant_trading_strategy_backtester.strategies.pairs_trading import (
     ],
 )
 def test_strategy_with_empty_data(
-    strategy_class: BaseStrategy, params: dict[str, Any]
+    strategy_class: type[BaseStrategy], params: dict[str, Any]
 ) -> None:
     empty_data = pl.DataFrame(
         schema=[("Close", pl.Float64)]
         if strategy_class != PairsTradingStrategy
         else [("Close_1", pl.Float64), ("Close_2", pl.Float64)]
     )
-    strategy = strategy_class(params)  # type: ignore
+    strategy = strategy_class(params)
     signals = strategy.generate_signals(empty_data)
 
     assert isinstance(signals, pl.DataFrame)

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -84,12 +84,12 @@ def _calculate_changes(values: list[float]) -> list[float]:
 )
 def test_backtester_initialisation(
     request: pytest.FixtureRequest,
-    strategy_class: BaseStrategy,
+    strategy_class: type[BaseStrategy],
     params: dict[str, Any],
     data_fixture: str,
 ) -> None:
     data = request.getfixturevalue(data_fixture)
-    strategy = strategy_class(params)  # type: ignore
+    strategy = strategy_class(params)
     backtester = Backtester(data, strategy)
 
     # Compare DataFrames
@@ -97,7 +97,7 @@ def test_backtester_initialisation(
     for col in data.columns:
         assert (backtester.data[col] == data[col]).all()
 
-    assert isinstance(backtester.strategy, strategy_class)  # type: ignore
+    assert isinstance(backtester.strategy, strategy_class)
     assert backtester.initial_capital == 100000.0
 
 
@@ -119,12 +119,12 @@ def test_backtester_initialisation(
 )
 def test_backtester_run(
     request: pytest.FixtureRequest,
-    strategy_class: BaseStrategy,
+    strategy_class: type[BaseStrategy],
     params: dict[str, Any],
     data_fixture: str,
 ) -> None:
     data = request.getfixturevalue(data_fixture)
-    strategy = strategy_class(params)  # type: ignore
+    strategy = strategy_class(params)
     backtester = Backtester(data, strategy)
     results = backtester.run()
     assert isinstance(results, pl.DataFrame)
@@ -161,12 +161,12 @@ def test_backtester_run(
 )
 def test_backtester_get_performance_metrics(
     request: pytest.FixtureRequest,
-    strategy_class: BaseStrategy,
+    strategy_class: type[BaseStrategy],
     params: dict[str, Any],
     data_fixture: str,
 ) -> None:
     data = request.getfixturevalue(data_fixture)
-    strategy = strategy_class(params)  # type: ignore
+    strategy = strategy_class(params)
     backtester = Backtester(data, strategy)
     backtester.run()
     metrics = backtester.get_performance_metrics()
@@ -200,7 +200,7 @@ def test_backtester_get_performance_metrics(
     ],
 )
 def test_backtester_with_invalid_data(
-    strategy_class: BaseStrategy, params: dict[str, Any]
+    strategy_class: type[BaseStrategy], params: dict[str, Any]
 ) -> None:
     dates = [datetime.date(2020, 1, 1) + datetime.timedelta(days=i) for i in range(10)]
     if strategy_class == PairsTradingStrategy:
@@ -220,7 +220,7 @@ def test_backtester_with_invalid_data(
             }
         )
 
-    strategy = strategy_class(params)  # type: ignore
+    strategy = strategy_class(params)
     backtester = Backtester(invalid_data, strategy)
 
     with pytest.raises((KeyError, ValueError, pl.exceptions.ColumnNotFoundError)):
@@ -239,7 +239,7 @@ def test_backtester_with_invalid_data(
     ],
 )
 def test_backtester_with_insufficient_data_all_strategies(
-    strategy_class: BaseStrategy, params: dict[str, Any]
+    strategy_class: type[BaseStrategy], params: dict[str, Any]
 ) -> None:
     dates = [datetime.date(2020, 1, 1), datetime.date(2020, 1, 2)]
     if strategy_class == PairsTradingStrategy:
@@ -258,7 +258,7 @@ def test_backtester_with_insufficient_data_all_strategies(
             }
         )
 
-    strategy = strategy_class(params)  # type: ignore
+    strategy = strategy_class(params)
     backtester = Backtester(insufficient_data, strategy)
     results = backtester.run()
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -57,8 +57,9 @@ def test_load_yfinance_data_two_tickers(
                 ("High", "MSFT"): base_data["High"],
             }
         )
+        # Pandas stubs lose tuple-key column types during DataFrame construction.
         multi_index_data.columns = pd.MultiIndex.from_tuples(
-            list(multi_index_data.columns)  # type: ignore[invalid-argument-type]
+            list(multi_index_data.columns)  # pyrefly: ignore[bad-argument-type]
         )
         return multi_index_data
 

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -1143,7 +1143,7 @@ def test_optimise_strategy_params_returns_test_metrics(monkeypatch):
         }
     )
 
-    call_log = []
+    call_log: list[tuple[str, int] | tuple[str, int, int]] = []
 
     def mock_run_backtest(data, strategy_type, params, tickers):
         call_log.append(("backtest", len(data)))

--- a/uv.lock
+++ b/uv.lock
@@ -690,6 +690,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pyrefly"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/01/a86e9f24722b095c3f88e3616132b75a21b0df53804bdc6a45314dd4d93c/pyrefly-1.2.0.tar.gz", hash = "sha256:5485f960fc2481617068c918335c39ab1507ef90b6b5bd35bf57726e60e73185", size = 6243654, upload-time = "2026-08-01T02:56:27.592Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/9d/3c0ef1d4843987b22f996ed381ec9cf5a3b1273e29804db276252e4c95eb/pyrefly-1.2.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7f46d983ac49ddd2b043694960a01dc6a19a5cfd8eec609d6bd9c42866f91b4e", size = 14026305, upload-time = "2026-08-01T02:56:02.611Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/06/03bbb78fbea54cdc65b626619f3597d5611aca4fdef11e72a4e8360e7e63/pyrefly-1.2.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:756f669b5555090f5c1a4fef30db1785fabe657764f7e4e6dc88994dfb8ca82d", size = 13463880, upload-time = "2026-08-01T02:56:04.93Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5a/7d8bc00a38e93bbc9c3e7bd14d305f7948717e667c9bcddeab9dd42fd255/pyrefly-1.2.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3465812ce5ef4781fb592edbf2724547296f0a3124be115d73c7e8b2401862d", size = 13907329, upload-time = "2026-08-01T02:56:07.104Z" },
+    { url = "https://files.pythonhosted.org/packages/be/94/9e08b4bf799d0b8f36b55a2783c7ba5f51730cf0632a85a67b5b5ed876cd/pyrefly-1.2.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5de7b2ad2bba5c8055181681a84b74143eac2234a48ba5d1b7ed7e7a722b02bd", size = 15039020, upload-time = "2026-08-01T02:56:09.208Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/bd/bca5fd0c80f4daf8ee6903a29df9f3de1feb05ff0946b8f35ec8c5096b13/pyrefly-1.2.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:25822ea9505f589ea8a725e4268b475132fb89e038fbf092e446510443ac142a", size = 14986199, upload-time = "2026-08-01T02:56:11.924Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f7/f07087f3d185ad2eced0c56cef89ca5474dfb4ff25f146cd50a861c97553/pyrefly-1.2.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90efe75e17491ef5d636e10469e9278d7d0256b3b4c5e1f4750069bf3ae0f5d1", size = 14393715, upload-time = "2026-08-01T02:56:14.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/70/0d142c320e284b9e3ce35e9b1e58b8ce2ee1f578f2a7234bc30e5022b94f/pyrefly-1.2.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:368aaf7eee4f511ddc0f8e564cf14e01ab2f10b0db9105c6d5b153bf498d07bf", size = 13933008, upload-time = "2026-08-01T02:56:16.525Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e8/e84f11b6e1f63fd453ad3654213b9a0f6f4de8cef6b58038eef2d0d5955d/pyrefly-1.2.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d52d5da7bc65fb7675fbaa80eda879d4f8787c494f04cac21603330d3abbdbbe", size = 14431827, upload-time = "2026-08-01T02:56:18.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/06/810d31380f66c75e1c0779a408d3b16117b1b368b57894f6aa66bef21686/pyrefly-1.2.0-py3-none-win32.whl", hash = "sha256:8c90751de8506d938e8f802659c74cf35bd7a0036510ee6c634a38eebb280bfa", size = 13229447, upload-time = "2026-08-01T02:56:20.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/98/4dafa3c7a1caed2dc8cc708dde09ba27963c7736508f55b626fff3024113/pyrefly-1.2.0-py3-none-win_amd64.whl", hash = "sha256:8a8964c224ccc4882730130955815de21ff443c1ac3f0b90685b19bf63848170", size = 14087387, upload-time = "2026-08-01T02:56:23.188Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1c/df3cb0a2e5591660ded7a1836cd2f29dc48c91adb1c0a3a700a96f6d09e1/pyrefly-1.2.0-py3-none-win_arm64.whl", hash = "sha256:3a90bb8df39dfbac74b1f3b2e9d7c526b8f80568884c3944d955023a73ebf61e", size = 13430873, upload-time = "2026-08-01T02:56:25.425Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -788,10 +807,10 @@ dev = [
     { name = "coverage" },
     { name = "pandas-stubs" },
     { name = "poethepoet" },
+    { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "ty" },
     { name = "watchdog" },
 ]
 
@@ -814,10 +833,10 @@ dev = [
     { name = "coverage", specifier = ">=7.6.0,<8.0.0" },
     { name = "pandas-stubs", specifier = ">=2.2.2.240603,<3.0.0.0" },
     { name = "poethepoet", specifier = ">=0.27.0,<1.0.0" },
+    { name = "pyrefly", specifier = ">=1.2.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "ruff", specifier = ">=0.16.0" },
-    { name = "ty", specifier = ">=0.0.21" },
     { name = "watchdog", specifier = ">=4.0.1,<5.0.0" },
 ]
 
@@ -1074,30 +1093,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
-]
-
-[[package]]
-name = "ty"
-version = "0.0.21"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/20/2ba8fd9493c89c41dfe9dbb73bc70a28b28028463bc0d2897ba8be36230a/ty-0.0.21.tar.gz", hash = "sha256:a4c2ba5d67d64df8fcdefd8b280ac1149d24a73dbda82fa953a0dff9d21400ed", size = 5297967, upload-time = "2026-03-06T01:57:13.809Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/70/edf38bb37517531681d1c37f5df64744e5ad02673c02eb48447eae4bea08/ty-0.0.21-py3-none-linux_armv6l.whl", hash = "sha256:7bdf2f572378de78e1f388d24691c89db51b7caf07cf90f2bfcc1d6b18b70a76", size = 10299222, upload-time = "2026-03-06T01:57:16.64Z" },
-    { url = "https://files.pythonhosted.org/packages/72/62/0047b0bd19afeefbc7286f20a5f78a2aa39f92b4d89853f0d7185ab89edc/ty-0.0.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7e9613994610431ab8625025bd2880dbcb77c5c9fabdd21134cda12d840a529d", size = 10130513, upload-time = "2026-03-06T01:57:29.93Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/20/0b93a9e91aaed23155780258cdfdb4726ef68b6985378ac069bc427291a0/ty-0.0.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:56d3b198b64dd0a19b2b66e257deaed2ecea568e722ae5352f3c6fb62027f89d", size = 9605425, upload-time = "2026-03-06T01:57:27.115Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/fd/9945e2fa2996a1287b1e1d7ce050e97e1f420233b271e770934bfa0880a0/ty-0.0.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d23d2c34f7a77d974bb08f0860ef700addc8a683d81a0319f71c08f87506cfd0", size = 10108298, upload-time = "2026-03-06T01:57:35.429Z" },
-    { url = "https://files.pythonhosted.org/packages/52/e7/4ec52fcb15f3200826c9f048472c062549a05b0d1ef0b51f32d527b513c4/ty-0.0.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56b01fd2519637a4ca88344f61c96225f540c98ff18bca321d4eaa7bb0f7aa2f", size = 10121556, upload-time = "2026-03-06T01:57:03.242Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/c0/ad457be2a8abea0f25549598bd098554540ced66229488daa0d558dad3c8/ty-0.0.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e9de7e11c63c6afc40f3e9ba716374add171aee7fabc70b5146a510705c6d41b", size = 10603264, upload-time = "2026-03-06T01:56:52.134Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/5b/2ecc7a2175243a4bcb72f5298ae41feabbb93b764bb0dc45722f3752c2c2/ty-0.0.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:62f7f5b235c4f7876db305c36997aea07b7af29b1a068f373d0e2547e25f32ff", size = 11196428, upload-time = "2026-03-06T01:57:32.94Z" },
-    { url = "https://files.pythonhosted.org/packages/37/f5/aff507d6a901f328ef96a298032b0c11aaaf950a146ed7dd3b5bf2cd3acf/ty-0.0.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee8399f7c453a425291e6688efe430cfae7ab0ac4ffd50eba9f872bf878b54f6", size = 10866355, upload-time = "2026-03-06T01:56:57.831Z" },
-    { url = "https://files.pythonhosted.org/packages/be/30/822bbcb92d55b65989aa7ed06d9585f28ade9c9447369194ed4b0fb3b5b9/ty-0.0.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:210e7568c9f886c4d01308d751949ee714ad7ad9d7d928d2ba90d329dd880367", size = 10738177, upload-time = "2026-03-06T01:57:11.256Z" },
-    { url = "https://files.pythonhosted.org/packages/57/cc/46e7991b6469e93ac2c7e533a028983e402485580150ac864c56352a3a82/ty-0.0.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:53508e345b11569f78b21ba8e2b4e61df38a9754947fb3cd9f2ef574367338fb", size = 10079158, upload-time = "2026-03-06T01:57:00.516Z" },
-    { url = "https://files.pythonhosted.org/packages/15/c2/0bbdadfbd008240f8f1a87dc877433cb3884436097926107ccf06e618199/ty-0.0.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:553e43571f4a35604c36cfd07d8b61a5eb7a714e3c67f8c4ff2cf674fefbaef9", size = 10150535, upload-time = "2026-03-06T01:57:08.815Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/b5/2dbdb7b57b5362200ef0a39738ebd31331726328336def0143ac097ee59d/ty-0.0.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:666f6822e3b9200abfa7e95eb0ddd576460adb8d66b550c0ad2c70abc84a2048", size = 10319803, upload-time = "2026-03-06T01:57:19.106Z" },
-    { url = "https://files.pythonhosted.org/packages/72/84/70e52c0b7abc7c2086f9876ef454a73b161d3125315536d8d7e911c94ca4/ty-0.0.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a0854d008347ce4a5fb351af132f660a390ab2a1163444d075251d43e6f74b9b", size = 10826239, upload-time = "2026-03-06T01:57:21.727Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/8a/1f72480fd013bbc6cd1929002abbbcde9a0b08ead6a15154de9d7f7fa37e/ty-0.0.21-py3-none-win32.whl", hash = "sha256:bef3ab4c7b966bcc276a8ac6c11b63ba222d21355b48d471ea782c4104eee4e0", size = 9693196, upload-time = "2026-03-06T01:57:24.126Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f8/1104808b875c26c640e536945753a78562d606bef4e241d9dbf3d92477f6/ty-0.0.21-py3-none-win_amd64.whl", hash = "sha256:a709d576e5bea84b745d43058d8b9cd4f27f74a0b24acb4b0cbb7d3d41e0d050", size = 10668660, upload-time = "2026-03-06T01:56:55.06Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/b8/25e0adc404bbf986977657b25318991f93097b49f8aea640d93c0b0db68e/ty-0.0.21-py3-none-win_arm64.whl", hash = "sha256:f72047996598ac20553fb7e21ba5741e3c82dee4e9eadf10d954551a5fe09391", size = 10104161, upload-time = "2026-03-06T01:57:06.072Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary
- Replaced Ty with Pyrefly as the repository’s development type checker and regenerated the locked environment
- Configured Pyrefly for Python 3.13 across application, test, and script sources, and made full-repository type checking a required CI gate
- Tightened annotations exposed by the migration and removed obsolete Ty suppressions
- Isolated unavoidable third-party typing limitations without weakening project-wide checking or changing runtime behaviour

## Rationale
- Pyrefly reports several typing contracts differently from Ty – every diagnostic was reviewed so genuine annotation defects were corrected rather than carried across behind broad suppressions
- SQLAlchemy and Polars expose broader static types than their runtime values, while pandas stubs lose tuple-column information – local casts and one error-code-specific suppression keep those limitations narrowly contained